### PR TITLE
sidebar with headless tree

### DIFF
--- a/examples/notion-clone/src/components/app-sidebar.tsx
+++ b/examples/notion-clone/src/components/app-sidebar.tsx
@@ -82,7 +82,7 @@ export function AppSidebar() {
         </SidebarGroup>
       </SidebarHeader>
       <SidebarContent>
-        <DocList group="document" title="Document" pages={[]} />
+        <DocList group="document" title="Document" pages={{}} />
       </SidebarContent>
       <SidebarFooter className="mb-10" />
       <SidebarRail />

--- a/packages/sidebar/src/presets/_components/doc-item.tsx
+++ b/packages/sidebar/src/presets/_components/doc-item.tsx
@@ -1,0 +1,94 @@
+import { cn } from "@notion-kit/cn";
+import { IconBlock } from "@notion-kit/icon-block";
+import { Icon } from "@notion-kit/icons";
+import type { IconData, Page, UpdatePageParams } from "@notion-kit/schemas";
+import {
+  Button,
+  MenuItem,
+  TreeItem,
+  TreeItemBase,
+  type ItemInstance,
+} from "@notion-kit/shadcn";
+
+import { DocItemActions } from "./doc-item-actions";
+
+interface DocItemProps {
+  item: ItemInstance<Page & TreeItemBase>;
+  type: "normal" | "favorites";
+  defaultIcon?: IconData;
+  onSelect?: (page: Page) => void;
+  onCreate?: (group: string, parentId?: string) => void;
+  onDuplicate?: (id: string) => void;
+  onUpdate?: (id: string, data: UpdatePageParams) => void;
+}
+
+export function DocItem({
+  item,
+  type,
+  defaultIcon = { type: "lucide", src: "file" },
+  onSelect,
+  onCreate,
+  onDuplicate,
+  onUpdate,
+}: DocItemProps) {
+  const node = item.getItemData();
+  const expandable = item.isFolder();
+  const expanded = item.isExpanded();
+  return (
+    <TreeItem item={item}>
+      <MenuItem
+        className={cn(
+          "group/doc-item",
+          "in-focus-visible:shadow-notion in-data-[drag-target=true]:cursor-grabbing in-data-[drag-target=true]:bg-default/10",
+          "in-data-[selected=true]:bg-default/10 in-data-[selected=true]:text-primary",
+        )}
+        variant="sidebar"
+        Icon={
+          <div className="group/icon">
+            <Button
+              variant="hint"
+              className={cn(
+                "relative hidden size-5 shrink-0",
+                expandable && "group-hover/icon:flex",
+              )}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (expanded) {
+                  item.collapse();
+                } else {
+                  item.expand();
+                }
+              }}
+              aria-label={expanded ? "collapse" : "expand"}
+            >
+              {expanded ? (
+                <Icon.ChevronDown className="size-2.5" />
+              ) : (
+                <Icon.ChevronRight className="size-2.5" />
+              )}
+            </Button>
+            <IconBlock
+              className={cn(expandable && "group-hover/icon:hidden")}
+              icon={node.icon ?? defaultIcon}
+            />
+          </div>
+        }
+        Body={node.title}
+        onClick={() => onSelect?.(node)}
+      >
+        <DocItemActions
+          type={type}
+          title={node.title}
+          icon={node.icon ?? defaultIcon}
+          pageLink={node.url ?? "#"}
+          isFavorite={node.isFavorite}
+          lastEditedBy={node.lastEditedBy}
+          lastEditedAt={node.lastEditedAt}
+          onCreate={() => onCreate?.(node.type, node.id)}
+          onDuplicate={() => onDuplicate?.(node.id)}
+          onUpdate={(data) => onUpdate?.(node.id, data)}
+        />
+      </MenuItem>
+    </TreeItem>
+  );
+}

--- a/packages/sidebar/src/presets/_components/index.ts
+++ b/packages/sidebar/src/presets/_components/index.ts
@@ -1,3 +1,4 @@
 export * from "./constant";
 export * from "./doc-group-actions";
+export * from "./doc-item";
 export * from "./workspace-list";

--- a/packages/sidebar/src/presets/favorite-list.tsx
+++ b/packages/sidebar/src/presets/favorite-list.tsx
@@ -3,13 +3,16 @@
 import React, { useState } from "react";
 
 import type { Page, UpdatePageParams } from "@notion-kit/schemas";
-import { TreeItem, TreeList, TreeNode } from "@notion-kit/tree";
+import { Tree } from "@notion-kit/shadcn";
 
 import { SidebarGroup, SidebarMenuItem } from "../core";
-import { DocItemActions } from "./_components/doc-item-actions";
+import { DocItem } from "./_components";
+import type { PageItems } from "./_lib";
+
+const ROOT_ID = "favorites";
 
 interface FavoriteListProps {
-  pages: TreeNode<Page>[];
+  pages: PageItems;
   activePage?: string | null;
   onSelect?: (page: Page) => void;
   onCreate?: (group: string, parentId?: string) => void;
@@ -18,7 +21,7 @@ interface FavoriteListProps {
 }
 
 export function FavoriteList({
-  pages: nodes,
+  pages,
   activePage,
   onSelect,
   onCreate,
@@ -36,33 +39,22 @@ export function FavoriteList({
         onClick={() => setShowList((prev) => !prev)}
       />
       {showList && (
-        <TreeList
+        <Tree
           indent={8}
-          nodes={nodes}
-          defaultIcon={{ type: "lucide", src: "file" }}
-          showEmptyChild
-          selectedId={activePage}
-          renderItem={({ node, ...props }) => (
-            <TreeItem
-              {...props}
-              node={node}
-              onSelect={() => onSelect?.(node)}
-              className="group/doc-item"
-              expandable
-            >
-              <DocItemActions
-                type="normal"
-                title={node.title}
-                icon={node.icon ?? { type: "lucide", src: "file" }}
-                pageLink={node.url ?? "#"}
-                isFavorite={node.isFavorite}
-                lastEditedBy={node.lastEditedBy}
-                lastEditedAt={node.lastEditedAt}
-                onCreate={() => onCreate?.(node.type, node.id)}
-                onDuplicate={() => onDuplicate?.(node.id)}
-                onUpdate={(data) => onUpdate?.(node.id, data)}
-              />
-            </TreeItem>
+          state={{ selectedItems: activePage ? [activePage] : [] }}
+          rootItemId={ROOT_ID}
+          items={pages}
+          isItemFolder={() => true}
+          renderItem={(item) => (
+            <DocItem
+              key={item.getId()}
+              item={item}
+              type="favorites"
+              onSelect={onSelect}
+              onCreate={onCreate}
+              onDuplicate={onDuplicate}
+              onUpdate={onUpdate}
+            />
           )}
         />
       )}


### PR DESCRIPTION

    


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a headless-tree powered Tree to our shadcn package and migrates the Sidebar document/favorites lists to it with drag-and-drop reparenting and improved item actions. Also switches apps to the internal icon set and refreshes theme variables for clearer, more consistent UI.

- New Features
  - New Tree (with DnD, selection, keyboard DnD) in @notion-kit/shadcn; Storybook demo added.
  - Sidebar DocList and FavoriteList rebuilt on Tree; new DocItem with inline expand/collapse and action menu; drag to re-parent updates via UpdatePageParams.parentId.
  - Expanded @notion-kit/icons and replaced lucide-react usage across sidebar, demos, and menus.
  - Theme tokens and variants updated (primary/secondary/icon/menu-icon, input bg) for better contrast; small UI polish across settings, selects, menus.

- Migration
  - DocList/FavoriteList pages prop now uses a PageItems map with an artificial root (group id or "favorites"); PagesStore.visibleByGroup/favorites return this shape. Optional onItemsDrop added for DnD; set UpdatePageParams.parentId on drop.
  - SidebarMenuItem: icon now accepts ReactNode (optional), not a LucideIcon type.
  - Replace lucide-react imports with @notion-kit/icons in consumers; add @notion-kit/icons dependency where used.
  - New deps in @notion-kit/shadcn: @headless-tree/core and @headless-tree/react (no app changes needed unless using Tree directly).

<sup>Written for commit 147bdf4750dcfb80d3ee0f15eb6d7100148015c9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



