### PR TITLE
feat: autocomplete, replace cmdk

### DIFF
--- a/apps/docs/content/docs/components/autocomplete.mdx
+++ b/apps/docs/content/docs/components/autocomplete.mdx
@@ -4,13 +4,85 @@ description: A Base UI autocomplete composed with Notion-style menu groups, item
 ---
 
 <ComponentPreview
-  name="autocomplete-menu"
-  preview={`<AutocompleteMenu />`}
+  name="autocomplete-default"
+  preview={`<Autocomplete items={groups} open autoHighlight="always" openOnInputClick>
+  <AutocompleteInput search clear placeholder="Search workspace..." />
+  <AutocompleteContent role="presentation">
+    <AutocompleteEmpty>No matches found.</AutocompleteEmpty>
+    <AutocompleteList>
+      {(group) => (
+        <AutocompleteGroup key={group.label} items={group.items}>
+          <AutocompleteLabel title={group.label} />
+          <AutocompleteCollection>
+            {(item) => (
+              <AutocompleteItem
+                key={item}
+                value={item}
+                label={item}
+                icon={group.icon}
+              >
+                <MenuItemAction className="text-xs text-muted">
+                  {group.label.slice(0, -1)}
+                </MenuItemAction>
+              </AutocompleteItem>
+            )}
+          </AutocompleteCollection>
+        </AutocompleteGroup>
+      )}
+    </AutocompleteList>
+  </AutocompleteContent>
+</Autocomplete>`}
 />
 
 ## Installation
 
-<Installation packages="@notion-kit/ui" registryName="autocomplete-menu" />
+<Installation packages="@notion-kit/ui" registryName="autocomplete-default" />
+
+## Examples
+
+---
+
+### Popover Menu
+
+Use `AutocompleteContent variant="inline"` when another primitive owns the overlay positioning. This keeps existing popover menus as `Popover` + `Autocomplete`.
+
+<ComponentPreview
+  name="autocomplete-popover"
+  preview={`<Popover>
+  <PopoverTrigger asChild>
+    <Button variant="hint" size="sm">Open menu</Button>
+  </PopoverTrigger>
+  <PopoverContent>
+    <Autocomplete items={groups} open autoHighlight="always" openOnInputClick>
+      <AutocompleteInput search clear placeholder="Search workspace..." />
+      <AutocompleteContent role="presentation" variant="inline">
+        <AutocompleteEmpty>No matches found.</AutocompleteEmpty>
+        <AutocompleteList>
+          {(group) => (
+            <AutocompleteGroup key={group.label} items={group.items}>
+              <AutocompleteLabel title={group.label} />
+              <AutocompleteCollection>
+                {(item) => (
+                  <AutocompleteItem
+                    key={item}
+                    value={item}
+                    label={item}
+                    icon={group.icon}
+                  >
+                    <MenuItemAction className="text-xs text-muted">
+                      {group.label.slice(0, -1)}
+                    </MenuItemAction>
+                  </AutocompleteItem>
+                )}
+              </AutocompleteCollection>
+            </AutocompleteGroup>
+          )}
+        </AutocompleteList>
+      </AutocompleteContent>
+    </Autocomplete>
+  </PopoverContent>
+</Popover>`}
+/>
 
 ## Anatomy
 
@@ -31,8 +103,137 @@ description: A Base UI autocomplete composed with Notion-style menu groups, item
 </Autocomplete>
 ```
 
+For grouped root items, render groups from `AutocompleteList`:
+
+```
+<Autocomplete items={groups}>
+  <AutocompleteInput />
+  <AutocompleteContent>
+    <AutocompleteEmpty />
+    <AutocompleteList>
+      {(group) => (
+        <AutocompleteGroup items={group.items}>
+          <AutocompleteLabel title={group.label} />
+          <AutocompleteCollection>
+            {(item) => <AutocompleteItem value={item} label={item} />}
+          </AutocompleteCollection>
+        </AutocompleteGroup>
+      )}
+    </AutocompleteList>
+  </AutocompleteContent>
+</Autocomplete>
+```
+
 ## API Reference
 
-Use `Autocomplete` as the Base UI root. Render items through `AutocompleteCollection` when the root receives `items`; this keeps filtering inside Base UI. `AutocompleteItem` uses the shared menu item visuals, so pass `icon`, `label`, `desc`, and trailing content through `MenuItemAction`.
+### Autocomplete
 
-Use `AutocompleteContent variant="inline"` for popover menus where the outer popover is already responsible for positioning.
+The Base UI autocomplete root. It owns the input value, filtering, highlight state, and item collection.
+
+| Prop                | Type                                           | Default | Description                                                   |
+| ------------------- | ---------------------------------------------- | ------- | ------------------------------------------------------------- |
+| `items`             | `Item[] \| { items: Item[] }[]`                | -       | Items to filter and render through `AutocompleteCollection`.  |
+| `itemToStringValue` | `(item: Item) => string`                       | -       | Converts object items to searchable text.                     |
+| `value`             | `string`                                       | -       | Controlled input value.                                       |
+| `onValueChange`     | `(value: string) => void`                      | -       | Handler called when the input value changes.                  |
+| `filter`            | Base UI filter function                        | -       | Optional custom filter. Prefer the internal filter by default. |
+| `filteredItems`     | `Item[] \| { items: Item[] }[]`                | -       | Controlled filtered result set.                               |
+| `open`              | `boolean`                                      | -       | Whether the autocomplete popup/list is open.                  |
+| `autoHighlight`     | `"always" \| "input" \| "none" \| boolean`    | -       | How Base UI highlights a matching item.                       |
+| `openOnInputClick`  | `boolean`                                      | -       | Opens the list when the input is clicked.                     |
+
+### AutocompleteInput
+
+The search input. It renders the shared `Input` primitive and supports the same visual affordances.
+
+| Prop        | Type                          | Default | Description                                  |
+| ----------- | ----------------------------- | ------- | -------------------------------------------- |
+| `search`    | `boolean`                     | -       | Shows the search icon.                       |
+| `clear`     | `boolean`                     | -       | Shows the clear affordance when there is text. |
+| `placeholder` | `string`                   | -       | Placeholder text for the input.              |
+| `onCancel`  | `() => void`                  | -       | Handler passed to the underlying input.      |
+| `classNames` | `{ wrapper?: string }`      | -       | Classes for the input wrapper.               |
+
+### AutocompleteContent
+
+The popup surface. Floating content is positioned by Base UI; inline content renders in-flow for composed menus.
+
+| Prop               | Type                    | Default      | Description                                      |
+| ------------------ | ----------------------- | ------------ | ------------------------------------------------ |
+| `variant`          | `"floating" \| "inline"` | `"floating"` | Whether to render a positioned popup or in-flow content. |
+| `side`             | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"` | Preferred side for floating content. |
+| `align`            | `"start" \| "center" \| "end"` | `"start"` | Preferred alignment for floating content. |
+| `sideOffset`       | `number`                | `4`          | Distance from the anchor for floating content.   |
+| `alignOffset`      | `number`                | -            | Alignment offset for floating content.           |
+| `collisionPadding` | `number \| Padding`     | -            | Padding used when avoiding viewport collisions.  |
+| `anchor`           | Base UI anchor          | -            | Custom anchor for floating content.              |
+
+### AutocompleteList
+
+The scrollable list viewport. When the root receives grouped items, pass a render function as children and render one `AutocompleteGroup` per group.
+
+| Prop       | Type                                              | Default | Description                         |
+| ---------- | ------------------------------------------------- | ------- | ----------------------------------- |
+| `children` | `React.ReactNode \| ((item, index) => ReactNode)` | -       | Static content or a Base UI item/group renderer. |
+
+### AutocompleteCollection
+
+Renders the filtered items from the nearest root or group.
+
+| Prop       | Type                         | Default | Description                         |
+| ---------- | ---------------------------- | ------- | ----------------------------------- |
+| `children` | `(item, index) => ReactNode` | -       | Renderer for each filtered item.    |
+
+### AutocompleteGroup
+
+Groups related autocomplete items with menu spacing.
+
+| Prop    | Type     | Default | Description                                                                 |
+| ------- | -------- | ------- | --------------------------------------------------------------------------- |
+| `items` | `Item[]` | -       | Group items. Use only when rendering a grouped root item from `AutocompleteList`. |
+
+For flat root items, keep the visual group item-less and let `AutocompleteCollection` read the root filtered items.
+
+### AutocompleteLabel
+
+A non-interactive label used to title a group of items.
+
+| Prop    | Type              | Default | Description                 |
+| ------- | ----------------- | ------- | --------------------------- |
+| `title` | `React.ReactNode` | -       | The group label content.    |
+
+### AutocompleteItem
+
+A single selectable autocomplete row. Extends the shared `MenuItem` visual props.
+
+| Prop      | Type                                                            | Default         | Description                              |
+| --------- | --------------------------------------------------------------- | --------------- | ---------------------------------------- |
+| `value`   | `Item`                                                          | -               | The item value selected by Base UI.      |
+| `label`   | `React.ReactNode`                                               | `String(value)` | The main item label.                     |
+| `icon`    | `React.ReactNode`                                               | -               | An optional leading icon.                |
+| `desc`    | `string`                                                        | -               | An optional description below the label. |
+| `variant` | `"default" \| "secondary" \| "sidebar" \| "warning" \| "error"` | `"default"`     | The visual style of the item.            |
+| `disabled` | `boolean`                                                      | -               | Whether the item is disabled.            |
+| `onClick` | `React.MouseEventHandler<HTMLElement>`                         | -               | Handler called when the item is clicked. |
+
+Use `MenuItemAction` as trailing content for metadata, status, or shortcuts.
+
+### AutocompleteEmpty
+
+Content shown only when Base UI reports an empty filtered result set.
+
+### AutocompleteSeparator
+
+A visual divider between autocomplete groups.
+
+### AutocompleteTrigger
+
+Optional trigger for autocomplete compositions that need a trigger affordance.
+
+### AutocompleteClear
+
+Clears the current autocomplete input value.
+
+### AutocompleteStatus
+
+Displays Base UI autocomplete status text.

--- a/apps/docs/content/docs/components/autocomplete.mdx
+++ b/apps/docs/content/docs/components/autocomplete.mdx
@@ -1,0 +1,38 @@
+---
+title: Autocomplete
+description: A Base UI autocomplete composed with Notion-style menu groups, items, labels, and separators.
+---
+
+<ComponentPreview
+  name="autocomplete-menu"
+  preview={`<AutocompleteMenu />`}
+/>
+
+## Installation
+
+<Installation packages="@notion-kit/ui" registryName="autocomplete-menu" />
+
+## Anatomy
+
+```
+<Autocomplete>
+  <AutocompleteInput />
+  <AutocompleteContent>
+    <AutocompleteEmpty />
+    <AutocompleteList>
+      <AutocompleteGroup>
+        <AutocompleteLabel />
+        <AutocompleteCollection>
+          <AutocompleteItem />
+        </AutocompleteCollection>
+      </AutocompleteGroup>
+    </AutocompleteList>
+  </AutocompleteContent>
+</Autocomplete>
+```
+
+## API Reference
+
+Use `Autocomplete` as the Base UI root. Render items through `AutocompleteCollection` when the root receives `items`; this keeps filtering inside Base UI. `AutocompleteItem` uses the shared menu item visuals, so pass `icon`, `label`, `desc`, and trailing content through `MenuItemAction`.
+
+Use `AutocompleteContent variant="inline"` for popover menus where the outer popover is already responsible for positioning.

--- a/apps/docs/content/docs/components/command.mdx
+++ b/apps/docs/content/docs/components/command.mdx
@@ -1,0 +1,35 @@
+---
+title: Command
+description: A dialog-only command palette built on the autocomplete primitive.
+---
+
+<ComponentPreview
+  name="command-dialog"
+  preview={`<CommandDialogDemo />`}
+/>
+
+## Installation
+
+<Installation packages="@notion-kit/ui" registryName="command-dialog" />
+
+## Anatomy
+
+```
+<CommandDialog>
+  <CommandInput />
+  <CommandList>
+    <CommandGroup>
+      <CommandCollection>
+        <CommandItem />
+      </CommandCollection>
+    </CommandGroup>
+    <CommandEmpty />
+  </CommandList>
+</CommandDialog>
+```
+
+## API Reference
+
+`Command` is intentionally exposed only as a dialog surface. Use `CommandDialog` for command palettes and use `Autocomplete` directly for popover menus.
+
+Pass `items` and `itemToStringValue` to `CommandDialog`, then render filtered rows through `CommandCollection`. `CommandItem` follows the menu item pattern: use `icon` and `label` props for the leading icon and main label, and use `MenuItemAction` for trailing metadata or shortcuts.

--- a/apps/docs/content/docs/components/command.mdx
+++ b/apps/docs/content/docs/components/command.mdx
@@ -5,7 +5,41 @@ description: A dialog-only command palette built on the autocomplete primitive.
 
 <ComponentPreview
   name="command-dialog"
-  preview={`<CommandDialogDemo />`}
+  preview={`<>
+  <Button size="sm" onClick={() => setOpen(true)}>
+    Open command
+  </Button>
+  <CommandDialog
+    open={open}
+    onOpenChange={setOpen}
+    items={actions}
+    itemToStringValue={(action) => action.label}
+    title="Workspace command palette"
+  >
+    <CommandInput search clear placeholder="Search actions..." />
+    <CommandList>
+      <CommandGroup heading="Actions">
+        <CommandCollection>
+          {(action) => (
+            <CommandItem
+              key={action.value}
+              value={action}
+              label={action.label}
+              icon={action.icon}
+              onClick={() => setOpen(false)}
+            >
+              <MenuItemAction className="flex items-center gap-2 text-xs text-muted">
+                <span>{action.section}</span>
+                <span>{action.shortcut}</span>
+              </MenuItemAction>
+            </CommandItem>
+          )}
+        </CommandCollection>
+      </CommandGroup>
+      <CommandEmpty>No commands found.</CommandEmpty>
+    </CommandList>
+  </CommandDialog>
+</>`}
 />
 
 ## Installation
@@ -30,6 +64,83 @@ description: A dialog-only command palette built on the autocomplete primitive.
 
 ## API Reference
 
-`Command` is intentionally exposed only as a dialog surface. Use `CommandDialog` for command palettes and use `Autocomplete` directly for popover menus.
+### CommandDialog
 
-Pass `items` and `itemToStringValue` to `CommandDialog`, then render filtered rows through `CommandCollection`. `CommandItem` follows the menu item pattern: use `icon` and `label` props for the leading icon and main label, and use `MenuItemAction` for trailing metadata or shortcuts.
+The dialog-only command palette root. It wraps `Dialog` and an always-open inline `Autocomplete`.
+
+Use `CommandDialog` for command palettes. Use `Autocomplete` directly for popover menus.
+
+| Prop                | Type                            | Default                          | Description                                      |
+| ------------------- | ------------------------------- | -------------------------------- | ------------------------------------------------ |
+| `open`              | `boolean`                       | -                                | Whether the dialog is open.                      |
+| `onOpenChange`      | `(open: boolean) => void`       | -                                | Handler called when the dialog opens or closes.  |
+| `items`             | `Item[] \| { items: Item[] }[]` | -                                | Items filtered by the internal autocomplete.     |
+| `itemToStringValue` | `(item: Item) => string`        | -                                | Converts object items to searchable text.        |
+| `filter`            | Base UI filter function         | -                                | Optional custom filter. Prefer the internal filter by default. |
+| `filteredItems`     | `Item[] \| { items: Item[] }[]` | -                                | Controlled filtered result set.                  |
+| `title`             | `string`                        | `"Command Palette"`              | Accessible dialog title rendered in an `sr-only` header. |
+| `description`       | `string`                        | `"Search for a command to run..."` | Accessible dialog description.                 |
+| `className`         | `string`                        | -                                | Classes applied to the dialog content.           |
+
+### CommandInput
+
+The command search input. Extends `AutocompleteInput`.
+
+| Prop          | Type                     | Default | Description                                  |
+| ------------- | ------------------------ | ------- | -------------------------------------------- |
+| `search`      | `boolean`                | -       | Shows the search icon.                       |
+| `clear`       | `boolean`                | -       | Shows the clear affordance when there is text. |
+| `placeholder` | `string`                 | -       | Placeholder text for the command input.      |
+| `classNames`  | `{ wrapper?: string }`   | -       | Classes for the input wrapper.               |
+
+### CommandList
+
+The scrollable command result list. Extends `AutocompleteList`.
+
+### CommandCollection
+
+Renders filtered command items from `CommandDialog`.
+
+| Prop       | Type                         | Default | Description                      |
+| ---------- | ---------------------------- | ------- | -------------------------------- |
+| `children` | `(item, index) => ReactNode` | -       | Renderer for each filtered item. |
+
+### CommandGroup
+
+Groups related command items.
+
+| Prop      | Type              | Default | Description              |
+| --------- | ----------------- | ------- | ------------------------ |
+| `heading` | `React.ReactNode` | -       | Optional group heading.  |
+| `items`   | `Item[]`          | -       | Group items for grouped root data. |
+
+For flat command palettes, do not pass `items` to `CommandGroup`; let `CommandCollection` read from `CommandDialog`.
+
+### CommandItem
+
+A single command row. Extends `AutocompleteItem`.
+
+| Prop       | Type                                                            | Default         | Description                              |
+| ---------- | --------------------------------------------------------------- | --------------- | ---------------------------------------- |
+| `value`    | `Item`                                                          | -               | The command value selected by Base UI.   |
+| `label`    | `React.ReactNode`                                               | `String(value)` | The main command label.                  |
+| `icon`     | `React.ReactNode`                                               | -               | An optional leading icon.                |
+| `desc`     | `string`                                                        | -               | An optional description below the label. |
+| `variant`  | `"default" \| "secondary" \| "sidebar" \| "warning" \| "error"` | `"default"`     | The visual style of the item.            |
+| `shortcut` | `React.ReactNode`                                               | -               | Shortcut rendered with `CommandShortcut`. |
+| `disabled` | `boolean`                                                       | -               | Whether the command is disabled.         |
+| `onClick`  | `React.MouseEventHandler<HTMLElement>`                          | -               | Handler called when the item is clicked. |
+
+Use `MenuItemAction` as trailing content for metadata or multi-part shortcuts.
+
+### CommandEmpty
+
+Content shown only when the filtered command result set is empty.
+
+### CommandSeparator
+
+A visual divider between command groups.
+
+### CommandShortcut
+
+Displays a keyboard shortcut hint aligned to the right of a command item.

--- a/apps/docs/src/__registry__/demos.tsx
+++ b/apps/docs/src/__registry__/demos.tsx
@@ -11,10 +11,16 @@ export const Index: Record<
     component: React.LazyExoticComponent<React.ComponentType<object>>;
   }
 > = {
-  "autocomplete-menu": {
-    files: ["registry/src/autocomplete-menu/autocomplete-menu.tsx"],
+  "autocomplete-default": {
+    files: ["registry/src/autocomplete-default/autocomplete-default.tsx"],
     component: React.lazy(
-      () => import("@notion-kit/registry/autocomplete-menu"),
+      () => import("@notion-kit/registry/autocomplete-default"),
+    ),
+  },
+  "autocomplete-popover": {
+    files: ["registry/src/autocomplete-popover/autocomplete-popover.tsx"],
+    component: React.lazy(
+      () => import("@notion-kit/registry/autocomplete-popover"),
     ),
   },
   "badge-default": {

--- a/apps/docs/src/__registry__/demos.tsx
+++ b/apps/docs/src/__registry__/demos.tsx
@@ -11,6 +11,12 @@ export const Index: Record<
     component: React.LazyExoticComponent<React.ComponentType<object>>;
   }
 > = {
+  "autocomplete-menu": {
+    files: ["registry/src/autocomplete-menu/autocomplete-menu.tsx"],
+    component: React.lazy(
+      () => import("@notion-kit/registry/autocomplete-menu"),
+    ),
+  },
   "badge-default": {
     files: ["registry/src/badge-default/badge-default.tsx"],
     component: React.lazy(() => import("@notion-kit/registry/badge-default")),
@@ -90,6 +96,10 @@ export const Index: Record<
     component: React.lazy(
       () => import("@notion-kit/registry/code-block-readonly"),
     ),
+  },
+  "command-dialog": {
+    files: ["registry/src/command-dialog/command-dialog.tsx"],
+    component: React.lazy(() => import("@notion-kit/registry/command-dialog")),
   },
   "context-menu": {
     files: ["registry/src/context-menu/context-menu.tsx"],

--- a/apps/docs/src/registry/demos.ts
+++ b/apps/docs/src/registry/demos.ts
@@ -7,7 +7,8 @@
  */
 export const DEMOS = [
   // Autocomplete
-  "autocomplete-menu",
+  "autocomplete-default",
+  "autocomplete-popover",
   // Badge
   "badge-default",
   "badge-sizes",

--- a/apps/docs/src/registry/demos.ts
+++ b/apps/docs/src/registry/demos.ts
@@ -6,6 +6,8 @@
  * 2. Auto-discover source files for the code preview panel
  */
 export const DEMOS = [
+  // Autocomplete
+  "autocomplete-menu",
   // Badge
   "badge-default",
   "badge-sizes",
@@ -27,6 +29,8 @@ export const DEMOS = [
   "code-block-default",
   "code-block-mermaid",
   "code-block-readonly",
+  // Command
+  "command-dialog",
   // Context Menu
   "context-menu",
   // Cover

--- a/apps/globe/src/plugins/common/transit-entity-search.tsx
+++ b/apps/globe/src/plugins/common/transit-entity-search.tsx
@@ -88,7 +88,7 @@ export function TransitEntitySearch<T>({
                 No matches found
               </AutocompleteEmpty>
             )}
-            <AutocompleteList className="max-h-100 overflow-y-auto">
+            <AutocompleteList className="max-h-100">
               {(group: (typeof groups)[number]) => {
                 if (group.label === "Recent" && group.items.length === 0) {
                   return null;

--- a/apps/globe/src/plugins/common/transit-entity-search.tsx
+++ b/apps/globe/src/plugins/common/transit-entity-search.tsx
@@ -83,44 +83,32 @@ export function TransitEntitySearch<T>({
         >
           <AutocompleteInput placeholder={placeholder} />
           <AutocompleteContent role="presentation" variant="inline">
+            {!isLoading && (
+              <AutocompleteEmpty className="py-6 text-center text-sm text-secondary">
+                No matches found
+              </AutocompleteEmpty>
+            )}
             <AutocompleteList className="max-h-100 overflow-y-auto">
-              {recentItems.length > 0 && (
-                <AutocompleteGroup
-                  className="flex flex-col gap-px px-0"
-                  items={recentItems}
-                >
-                  <AutocompleteLabel title="Recent" />
-                  <AutocompleteCollection>
-                    {(item: TransitSearchItem<T>) => (
-                      <SearchItem
-                        key={`recent-${item.key}`}
-                        item={item}
-                        onSelect={handleSelect}
-                      />
-                    )}
-                  </AutocompleteCollection>
-                </AutocompleteGroup>
-              )}
-              <AutocompleteGroup
-                className="flex flex-col gap-px px-0"
-                items={items}
-              >
-                <AutocompleteLabel title={label} />
-                <AutocompleteCollection>
-                  {(item: TransitSearchItem<T>) => (
-                    <SearchItem
-                      key={item.key}
-                      item={item}
-                      onSelect={handleSelect}
-                    />
-                  )}
-                </AutocompleteCollection>
-              </AutocompleteGroup>
-              {!isLoading && (
-                <AutocompleteEmpty className="py-6 text-center text-sm text-secondary">
-                  No matches found
-                </AutocompleteEmpty>
-              )}
+              {(group: (typeof groups)[number]) => {
+                if (group.label === "Recent" && group.items.length === 0) {
+                  return null;
+                }
+
+                return (
+                  <AutocompleteGroup key={group.label} items={group.items}>
+                    <AutocompleteLabel title={group.label} />
+                    <AutocompleteCollection>
+                      {(item: TransitSearchItem<T>) => (
+                        <SearchItem
+                          key={`${group.label}-${item.key}`}
+                          item={item}
+                          onSelect={handleSelect}
+                        />
+                      )}
+                    </AutocompleteCollection>
+                  </AutocompleteGroup>
+                );
+              }}
             </AutocompleteList>
           </AutocompleteContent>
         </Autocomplete>

--- a/apps/globe/src/plugins/common/transit-entity-search.tsx
+++ b/apps/globe/src/plugins/common/transit-entity-search.tsx
@@ -1,14 +1,16 @@
 import { useMemo, useState } from "react";
 
-import { cn } from "@notion-kit/cn";
 import { Icon } from "@notion-kit/icons";
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteEmpty,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteLabel,
+  AutocompleteList,
   MenuItem,
   Popover,
   PopoverContent,
@@ -46,14 +48,13 @@ export function TransitEntitySearch<T>({
 }: TransitEntitySearchProps<T>) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-
-  const filteredItems = useMemo(() => {
-    const query = search.trim().toLowerCase();
-    if (!query) return items.slice(0, 80);
-    return items
-      .filter((item) => item.searchText.toLowerCase().includes(query))
-      .slice(0, 80);
-  }, [items, search]);
+  const groups = useMemo(
+    () => [
+      { label: "Recent", items: recentItems },
+      { label, items },
+    ],
+    [items, label, recentItems],
+  );
 
   function handleSelect(item: TransitSearchItem<T>) {
     onSelect(item.value);
@@ -71,51 +72,62 @@ export function TransitEntitySearch<T>({
         />
       </PopoverTrigger>
       <PopoverContent align="start" className="w-[342px] p-0">
-        <Command shouldFilter={false}>
-          <CommandInput
-            value={search}
-            onValueChange={setSearch}
-            placeholder={placeholder}
-          />
-          <CommandList className="max-h-100 overflow-y-auto">
-            {recentItems.length > 0 && (
-              <CommandGroup className={commandGroupClassName} heading="Recent">
-                {recentItems.map((item) => (
-                  <SearchItem
-                    key={`recent-${item.key}`}
-                    item={item}
-                    onSelect={handleSelect}
-                  />
-                ))}
-              </CommandGroup>
-            )}
-
-            <CommandGroup className={commandGroupClassName} heading={label}>
-              {filteredItems.map((item) => (
-                <SearchItem
-                  key={item.key}
-                  item={item}
-                  onSelect={handleSelect}
-                />
-              ))}
-            </CommandGroup>
-
-            {!isLoading && filteredItems.length === 0 && (
-              <CommandEmpty className="py-6 text-center text-sm text-secondary">
-                No matches found
-              </CommandEmpty>
-            )}
-          </CommandList>
-        </Command>
+        <Autocomplete<TransitSearchItem<T>>
+          items={groups}
+          itemToStringValue={(item) => item.searchText}
+          value={search}
+          onValueChange={setSearch}
+          open
+          autoHighlight="always"
+          openOnInputClick
+        >
+          <AutocompleteInput placeholder={placeholder} />
+          <AutocompleteContent role="presentation" variant="inline">
+            <AutocompleteList className="max-h-100 overflow-y-auto">
+              {recentItems.length > 0 && (
+                <AutocompleteGroup
+                  className="flex flex-col gap-px px-0"
+                  items={recentItems}
+                >
+                  <AutocompleteLabel title="Recent" />
+                  <AutocompleteCollection>
+                    {(item: TransitSearchItem<T>) => (
+                      <SearchItem
+                        key={`recent-${item.key}`}
+                        item={item}
+                        onSelect={handleSelect}
+                      />
+                    )}
+                  </AutocompleteCollection>
+                </AutocompleteGroup>
+              )}
+              <AutocompleteGroup
+                className="flex flex-col gap-px px-0"
+                items={items}
+              >
+                <AutocompleteLabel title={label} />
+                <AutocompleteCollection>
+                  {(item: TransitSearchItem<T>) => (
+                    <SearchItem
+                      key={item.key}
+                      item={item}
+                      onSelect={handleSelect}
+                    />
+                  )}
+                </AutocompleteCollection>
+              </AutocompleteGroup>
+              {!isLoading && (
+                <AutocompleteEmpty className="py-6 text-center text-sm text-secondary">
+                  No matches found
+                </AutocompleteEmpty>
+              )}
+            </AutocompleteList>
+          </AutocompleteContent>
+        </Autocomplete>
       </PopoverContent>
     </Popover>
   );
 }
-
-const commandGroupClassName = cn(
-  "flex flex-col gap-px px-0",
-  "**:[[cmdk-group-heading]]:mt-1.5 **:[[cmdk-group-heading]]:mb-2 **:[[cmdk-group-heading]]:flex **:[[cmdk-group-heading]]:items-center **:[[cmdk-group-heading]]:truncate **:[[cmdk-group-heading]]:px-3.5 **:[[cmdk-group-heading]]:py-0 **:[[cmdk-group-heading]]:leading-tight **:[[cmdk-group-heading]]:text-secondary **:[[cmdk-group-heading]]:select-none",
-);
 
 interface SearchItemProps<T> {
   item: TransitSearchItem<T>;
@@ -124,24 +136,20 @@ interface SearchItemProps<T> {
 
 function SearchItem<T>({ item, onSelect }: SearchItemProps<T>) {
   return (
-    <CommandItem
-      asChild
-      value={item.searchText}
-      onSelect={() => onSelect(item)}
-    >
-      <MenuItem
-        className="h-12"
-        label={
-          <span
-            className="max-w-16 truncate rounded-sm px-1.5 text-xs font-bold text-white"
-            style={{ backgroundColor: normalizeBadgeColor(item.color) }}
-          >
-            {item.title}
-          </span>
-        }
-        desc={item.subtitle}
-      ></MenuItem>
-    </CommandItem>
+    <AutocompleteItem
+      value={item}
+      className="h-12"
+      label={
+        <span
+          className="max-w-16 truncate rounded-sm px-1.5 text-xs font-bold text-white"
+          style={{ backgroundColor: normalizeBadgeColor(item.color) }}
+        >
+          {item.title}
+        </span>
+      }
+      desc={item.subtitle}
+      onClick={() => onSelect(item)}
+    />
   );
 }
 

--- a/apps/storybook/src/stories/ui/autocomplete.stories.tsx
+++ b/apps/storybook/src/stories/ui/autocomplete.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "storybook-react-rsbuild";
+
+import AutocompleteDefault from "@notion-kit/registry/autocomplete-default";
+import AutocompletePopover from "@notion-kit/registry/autocomplete-popover";
+
+const meta = {
+  title: "Shadcn/Autocomplete",
+  parameters: { layout: "centered" },
+} satisfies Meta;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => <AutocompleteDefault />,
+};
+
+export const PopoverMenu: Story = {
+  render: () => <AutocompletePopover />,
+};

--- a/apps/storybook/src/stories/ui/command.stories.tsx
+++ b/apps/storybook/src/stories/ui/command.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "storybook-react-rsbuild";
+
+import CommandDialogDemo from "@notion-kit/registry/command-dialog";
+
+const meta = {
+  title: "Shadcn/Command",
+  parameters: { layout: "centered" },
+} satisfies Meta;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Dialog: Story = {
+  render: () => <CommandDialogDemo />,
+};

--- a/issues.md
+++ b/issues.md
@@ -14,7 +14,10 @@ issues recording for current task
    1. [solved] item check indicator positioned wrong!
    2. [solved] SelectItem should wrapped in SelectGroup!
    3. [solved] Select content weird layout...
-10. command-item rendered with menu-item becomes DISABLED!!!
+10. ~~command-item rendered with menu-item becomes DISABLED!!!~~
 11. [solved] separators in menu are all with height 0!
-12. menu content or portal issues!
+12. menu issues!
     1. content or portal z-index wrong!
+13. in table-view
+    1. many menus are still not working as expected (e.g. popover + menu primitives). they can probably changed into dropdown-menu
+    2. sort-menu.tsx -> the SelectContent's in the SortRule are not visible, not sure if they are caused by issue 12.1

--- a/packages/code-block/src/code-block-actions.tsx
+++ b/packages/code-block/src/code-block-actions.tsx
@@ -1,16 +1,18 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 
 import { useCopyToClipboard } from "@notion-kit/hooks";
 import { Icon } from "@notion-kit/icons";
 import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteLabel,
+  AutocompleteList,
+  AutocompleteSeparator,
   MenuFooter,
-  MenuItem,
   MenuItemAction,
   MenuItemSelect,
   MenuItemShortcut,
@@ -35,93 +37,166 @@ export function CodeBlockActions() {
   const [openThemeSelect, setOpenThemeSelect] = useState(false);
   const [openLangSelect, setOpenLangSelect] = useState(false);
 
+  type CodeAction = {
+    value: string;
+    name: string;
+    icon: ReactNode;
+    shortcut?: string;
+    action?: ReactNode;
+    onClick?: () => void | Promise<void>;
+    popover?: "language" | "theme";
+  };
+
+  const actions: CodeAction[] = [];
+
+  if (!readonly) {
+    actions.push({
+      value: "caption",
+      name: "Caption",
+      icon: <Icon.Caption />,
+      shortcut: `${KEYBOARD.CMD}${KEYBOARD.OPTION}M`,
+      onClick: () => store.enableCaption(),
+    });
+  }
+
+  actions.push(
+    {
+      value: "copy-code",
+      name: "Copy code",
+      icon: <Icon.CopyCode />,
+      onClick: () => copy(state.code),
+    },
+    {
+      value: "wrap-code",
+      name: "Wrap code",
+      icon: <Icon.ArrowTurnDownLeft />,
+      onClick: store.toggleWrap,
+      action: (
+        <MenuItemAction>
+          <Switch size="sm" checked={state.wrap} />
+        </MenuItemAction>
+      ),
+    },
+  );
+
+  if (!readonly) {
+    actions.push({
+      value: "language",
+      name: "Language",
+      icon: <Icon.CurlyBraces />,
+      popover: "language" as const,
+    });
+  }
+
+  if (!readonly && isFormattable(state.lang)) {
+    actions.push({
+      value: "format-code",
+      name: "Format code",
+      icon: <Icon.Lightning />,
+      onClick: store.formatCode,
+    });
+  }
+
+  actions.push(
+    {
+      value: "theme",
+      name: "Theme",
+      icon: <Icon.EmojiFace />,
+      popover: "theme" as const,
+    },
+  );
+
   return (
-    <Command shouldFilter>
-      <CommandInput placeholder="Search actions..." />
-      <CommandList>
-        <CommandGroup heading="Code">
-          {!readonly && (
-            <CommandItem
-              asChild
-              value="caption"
-              onSelect={() => store.enableCaption()}
-            >
-              <MenuItem icon={<Icon.Caption />} label="Caption">
-                <MenuItemShortcut>
-                  {KEYBOARD.CMD}
-                  {KEYBOARD.OPTION}M
-                </MenuItemShortcut>
-              </MenuItem>
-            </CommandItem>
-          )}
-          <CommandItem
-            asChild
-            value="copy-code"
-            onSelect={() => copy(state.code)}
-          >
-            <MenuItem icon={<Icon.CopyCode />} label="Copy code" />
-          </CommandItem>
-          <CommandItem asChild value="wrap-code" onSelect={store.toggleWrap}>
-            <MenuItem icon={<Icon.ArrowTurnDownLeft />} label="Wrap code">
-              <MenuItemAction>
-                <Switch size="sm" checked={state.wrap} />
-              </MenuItemAction>
-            </MenuItem>
-          </CommandItem>
-          {!readonly && (
-            <Popover open={openLangSelect} onOpenChange={setOpenLangSelect}>
-              <PopoverTrigger asChild>
-                <CommandItem
-                  asChild
-                  value="language"
-                  onPointerEnter={() => setOpenLangSelect(true)}
-                  onSelect={() => setOpenLangSelect((v) => !v)}
-                >
-                  <MenuItem icon={<Icon.CurlyBraces />} label="Language">
-                    <MenuItemSelect />
-                  </MenuItem>
-                </CommandItem>
-              </PopoverTrigger>
-              <PopoverContent side="left" className="w-60">
-                <LangMenu />
-              </PopoverContent>
-            </Popover>
-          )}
-          {!readonly && isFormattable(state.lang) && (
-            <CommandItem
-              asChild
-              value="format-code"
-              onSelect={store.formatCode}
-            >
-              <MenuItem icon={<Icon.Lightning />} label="Format code" />
-            </CommandItem>
-          )}
-          <Popover open={openThemeSelect} onOpenChange={setOpenThemeSelect}>
-            <PopoverTrigger asChild>
-              <CommandItem
-                asChild
-                value="theme"
-                onPointerEnter={() => setOpenThemeSelect(true)}
-                onSelect={() => setOpenThemeSelect((v) => !v)}
-              >
-                <MenuItem icon={<Icon.EmojiFace />} label="Theme">
-                  <MenuItemSelect />
-                </MenuItem>
-              </CommandItem>
-            </PopoverTrigger>
-            <PopoverContent side="left" className="w-60">
-              <ThemeMenu />
-            </PopoverContent>
-          </Popover>
-        </CommandGroup>
-        <CommandSeparator />
-        <MenuFooter>
-          {lastEditedBy && (
-            <div className="w-full">Last edited by {lastEditedBy}</div>
-          )}
-          <div className="w-full">{toDateString(state.ts)}</div>
-        </MenuFooter>
-      </CommandList>
-    </Command>
+    <Autocomplete
+      items={actions}
+      itemToStringValue={(action) => action.name}
+      open
+      autoHighlight="always"
+      openOnInputClick
+    >
+      <AutocompleteInput placeholder="Search actions..." />
+      <AutocompleteContent role="presentation" variant="inline">
+        <AutocompleteList>
+          <AutocompleteGroup items={actions}>
+            <AutocompleteLabel title="Code" />
+            <AutocompleteCollection>
+              {(action: (typeof actions)[number]) => {
+                if (action.popover === "language") {
+                  return (
+                    <Popover
+                      key={action.value}
+                      open={openLangSelect}
+                      onOpenChange={setOpenLangSelect}
+                    >
+                      <PopoverTrigger asChild>
+                        <AutocompleteItem
+                          value={action}
+                          icon={action.icon}
+                          label={action.name}
+                          onPointerEnter={() => setOpenLangSelect(true)}
+                          onClick={() => setOpenLangSelect((v) => !v)}
+                        >
+                          <MenuItemSelect />
+                        </AutocompleteItem>
+                      </PopoverTrigger>
+                      <PopoverContent side="left" className="w-60">
+                        <LangMenu />
+                      </PopoverContent>
+                    </Popover>
+                  );
+                }
+
+                if (action.popover === "theme") {
+                  return (
+                    <Popover
+                      key={action.value}
+                      open={openThemeSelect}
+                      onOpenChange={setOpenThemeSelect}
+                    >
+                      <PopoverTrigger asChild>
+                        <AutocompleteItem
+                          value={action}
+                          icon={action.icon}
+                          label={action.name}
+                          onPointerEnter={() => setOpenThemeSelect(true)}
+                          onClick={() => setOpenThemeSelect((v) => !v)}
+                        >
+                          <MenuItemSelect />
+                        </AutocompleteItem>
+                      </PopoverTrigger>
+                      <PopoverContent side="left" className="w-60">
+                        <ThemeMenu />
+                      </PopoverContent>
+                    </Popover>
+                  );
+                }
+
+                return (
+                  <AutocompleteItem
+                    key={action.value}
+                    value={action}
+                    icon={action.icon}
+                    label={action.name}
+                    onClick={action.onClick}
+                  >
+                    {action.shortcut && (
+                      <MenuItemShortcut>{action.shortcut}</MenuItemShortcut>
+                    )}
+                    {action.action}
+                  </AutocompleteItem>
+                );
+              }}
+            </AutocompleteCollection>
+          </AutocompleteGroup>
+          <AutocompleteSeparator />
+          <MenuFooter>
+            {lastEditedBy && (
+              <div className="w-full">Last edited by {lastEditedBy}</div>
+            )}
+            <div className="w-full">{toDateString(state.ts)}</div>
+          </MenuFooter>
+        </AutocompleteList>
+      </AutocompleteContent>
+    </Autocomplete>
   );
 }

--- a/packages/code-block/src/code-block-actions.tsx
+++ b/packages/code-block/src/code-block-actions.tsx
@@ -28,6 +28,16 @@ import { useCodeBlock } from "./code-block-provider";
 import { LangMenu, ThemeMenu } from "./menus";
 import { isFormattable } from "./transformers";
 
+interface CodeAction {
+  value: string;
+  name: string;
+  icon: ReactNode;
+  shortcut?: string;
+  action?: ReactNode;
+  onClick?: () => void | Promise<void>;
+  popover?: "language" | "theme";
+}
+
 export function CodeBlockActions() {
   const { state, store, lastEditedBy, readonly } = useCodeBlock();
   const { copy } = useCopyToClipboard({
@@ -36,16 +46,6 @@ export function CodeBlockActions() {
 
   const [openThemeSelect, setOpenThemeSelect] = useState(false);
   const [openLangSelect, setOpenLangSelect] = useState(false);
-
-  type CodeAction = {
-    value: string;
-    name: string;
-    icon: ReactNode;
-    shortcut?: string;
-    action?: ReactNode;
-    onClick?: () => void | Promise<void>;
-    popover?: "language" | "theme";
-  };
 
   const actions: CodeAction[] = [];
 
@@ -97,14 +97,12 @@ export function CodeBlockActions() {
     });
   }
 
-  actions.push(
-    {
-      value: "theme",
-      name: "Theme",
-      icon: <Icon.EmojiFace />,
-      popover: "theme" as const,
-    },
-  );
+  actions.push({
+    value: "theme",
+    name: "Theme",
+    icon: <Icon.EmojiFace />,
+    popover: "theme" as const,
+  });
 
   return (
     <Autocomplete
@@ -117,10 +115,10 @@ export function CodeBlockActions() {
       <AutocompleteInput placeholder="Search actions..." />
       <AutocompleteContent role="presentation" variant="inline">
         <AutocompleteList>
-          <AutocompleteGroup items={actions}>
+          <AutocompleteGroup>
             <AutocompleteLabel title="Code" />
             <AutocompleteCollection>
-              {(action: (typeof actions)[number]) => {
+              {(action: CodeAction) => {
                 if (action.popover === "language") {
                   return (
                     <Popover

--- a/packages/code-block/src/menus/lang-menu.tsx
+++ b/packages/code-block/src/menus/lang-menu.tsx
@@ -1,39 +1,54 @@
-"use client";
-
 import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  MenuItem,
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteLabel,
+  AutocompleteList,
   MenuItemCheck,
 } from "@notion-kit/ui/primitives";
 
 import { useCodeBlock } from "../code-block-provider";
 import { CODE_BLOCK_LANGUAGES } from "../constant";
 
+const OPTIONS = [{ value: "Languages", items: CODE_BLOCK_LANGUAGES }];
+type OptionGroup = (typeof OPTIONS)[number];
+type Language = (typeof CODE_BLOCK_LANGUAGES)[number];
+
 export function LangMenu() {
   const { state, store } = useCodeBlock();
   return (
-    <Command className="bg-popover">
-      <CommandInput placeholder="Search for a language..." />
-      <CommandList className="max-h-60">
-        <CommandGroup className="flex flex-col gap-px px-0">
-          {CODE_BLOCK_LANGUAGES.map((lang) => (
-            <CommandItem
-              asChild
-              key={lang.value}
-              value={lang.value}
-              onSelect={(lang) => store.setLang(lang)}
-            >
-              <MenuItem label={lang.label}>
-                {lang.value === state.lang && <MenuItemCheck />}
-              </MenuItem>
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      </CommandList>
-    </Command>
+    <Autocomplete<Language>
+      items={OPTIONS}
+      itemToStringValue={(lang) => lang.label}
+      open
+      autoHighlight="always"
+      openOnInputClick
+    >
+      <AutocompleteInput placeholder="Search for a language..." />
+      <AutocompleteContent role="presentation" variant="inline">
+        <AutocompleteList className="max-h-60">
+          {(group: OptionGroup) => (
+            <AutocompleteGroup key={group.value} items={group.items}>
+              <AutocompleteLabel title={group.value} />
+              <AutocompleteCollection>
+                {(lang: Language) => (
+                  <AutocompleteItem
+                    key={lang.value}
+                    value={lang}
+                    label={lang.label}
+                    onClick={() => store.setLang(lang.value)}
+                  >
+                    {lang.value === state.lang && <MenuItemCheck />}
+                  </AutocompleteItem>
+                )}
+              </AutocompleteCollection>
+            </AutocompleteGroup>
+          )}
+        </AutocompleteList>
+      </AutocompleteContent>
+    </Autocomplete>
   );
 }

--- a/packages/code-block/src/menus/theme-menu.tsx
+++ b/packages/code-block/src/menus/theme-menu.tsx
@@ -1,38 +1,59 @@
 import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  MenuItem,
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteLabel,
+  AutocompleteList,
   MenuItemCheck,
 } from "@notion-kit/ui/primitives";
 
 import { useCodeBlock } from "../code-block-provider";
 import { CODE_BLOCK_THEMES } from "../constant";
 
+const OPTIONS = [{ value: "Themes", items: CODE_BLOCK_THEMES }];
+type OptionGroup = (typeof OPTIONS)[number];
+type Theme = (typeof CODE_BLOCK_THEMES)[number];
+
 export function ThemeMenu() {
   const { state, store } = useCodeBlock();
 
   return (
-    <Command className="bg-popover">
-      <CommandInput placeholder="Search themes..." />
-      <CommandList className="max-h-60">
-        <CommandGroup heading="Themes">
-          {CODE_BLOCK_THEMES.map((theme) => (
-            <CommandItem
-              asChild
-              key={theme.value}
-              value={theme.value}
-              onSelect={() => store.setTheme(theme.value)}
-            >
-              <MenuItem label={theme.label}>
-                {theme.value === state.theme && <MenuItemCheck />}
-              </MenuItem>
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      </CommandList>
-    </Command>
+    <Autocomplete<Theme>
+      items={OPTIONS}
+      itemToStringValue={(theme) => theme.label}
+      open
+      autoHighlight="always"
+      openOnInputClick
+    >
+      <AutocompleteInput placeholder="Search themes..." />
+      <AutocompleteContent
+        role="presentation"
+        variant="inline"
+        className="bg-popover"
+      >
+        <AutocompleteList className="max-h-60">
+          {(group: OptionGroup) => (
+            <AutocompleteGroup key={group.value} items={group.items}>
+              <AutocompleteLabel title={group.value} />
+              <AutocompleteCollection>
+                {(theme: Theme) => (
+                  <AutocompleteItem
+                    key={theme.value}
+                    value={theme}
+                    label={theme.label}
+                    onClick={() => store.setTheme(theme.value)}
+                  >
+                    {theme.value === state.theme && <MenuItemCheck />}
+                  </AutocompleteItem>
+                )}
+              </AutocompleteCollection>
+            </AutocompleteGroup>
+          )}
+        </AutocompleteList>
+      </AutocompleteContent>
+    </Autocomplete>
   );
 }

--- a/packages/registry/src/autocomplete-default/autocomplete-default.tsx
+++ b/packages/registry/src/autocomplete-default/autocomplete-default.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Icon } from "@notion-kit/icons";
+import {
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteEmpty,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteLabel,
+  AutocompleteList,
+  MenuItemAction,
+} from "@notion-kit/ui/primitives";
+
+const PAGES = ["Project plan", "Release notes", "Design system"];
+const ACTIONS = ["Invite members", "Archive page", "Export workspace"];
+
+const GROUPS = [
+  {
+    label: "Pages",
+    items: PAGES,
+    icon: <Icon.Newspaper className="size-4 fill-menu-icon" />,
+  },
+  {
+    label: "Actions",
+    items: ACTIONS,
+    icon: <Icon.Lightning className="size-4 fill-menu-icon" />,
+  },
+];
+
+export default function AutocompleteDefault() {
+  return (
+    <div className="w-80">
+      <Autocomplete<string>
+        items={GROUPS}
+        open
+        autoHighlight="always"
+        openOnInputClick
+      >
+        <AutocompleteInput search clear placeholder="Search workspace..." />
+        <AutocompleteContent role="presentation">
+          <AutocompleteEmpty>No matches found.</AutocompleteEmpty>
+          <AutocompleteList>
+            {(group: (typeof GROUPS)[number]) => (
+              <AutocompleteGroup key={group.label} items={group.items}>
+                <AutocompleteLabel title={group.label} />
+                <AutocompleteCollection>
+                  {(item: string) => (
+                    <AutocompleteItem
+                      key={item}
+                      value={item}
+                      label={item}
+                      icon={group.icon}
+                    >
+                      <MenuItemAction className="text-xs text-muted">
+                        {group.label.slice(0, -1)}
+                      </MenuItemAction>
+                    </AutocompleteItem>
+                  )}
+                </AutocompleteCollection>
+              </AutocompleteGroup>
+            )}
+          </AutocompleteList>
+        </AutocompleteContent>
+      </Autocomplete>
+    </div>
+  );
+}

--- a/packages/registry/src/autocomplete-default/index.ts
+++ b/packages/registry/src/autocomplete-default/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./autocomplete-default";

--- a/packages/registry/src/autocomplete-popover/autocomplete-popover.tsx
+++ b/packages/registry/src/autocomplete-popover/autocomplete-popover.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Icon } from "@notion-kit/icons";
+import {
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteEmpty,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteLabel,
+  AutocompleteList,
+  Button,
+  MenuItemAction,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@notion-kit/ui/primitives";
+
+const PAGES = ["Project plan", "Release notes", "Design system"];
+const ACTIONS = ["Invite members", "Archive page", "Export workspace"];
+
+const GROUPS = [
+  {
+    label: "Pages",
+    items: PAGES,
+    icon: <Icon.Newspaper className="size-4 fill-menu-icon" />,
+  },
+  {
+    label: "Actions",
+    items: ACTIONS,
+    icon: <Icon.Lightning className="size-4 fill-menu-icon" />,
+  },
+];
+
+export default function AutocompletePopover() {
+  return (
+    <Popover defaultOpen>
+      <PopoverTrigger asChild>
+        <Button variant="hint" size="sm">
+          Open menu
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <Autocomplete<string>
+          items={GROUPS}
+          open
+          autoHighlight="always"
+          openOnInputClick
+        >
+          <AutocompleteInput search clear placeholder="Search workspace..." />
+          <AutocompleteContent role="presentation" variant="inline">
+            <AutocompleteEmpty>No matches found.</AutocompleteEmpty>
+            <AutocompleteList>
+              {(group: (typeof GROUPS)[number]) => (
+                <AutocompleteGroup key={group.label} items={group.items}>
+                  <AutocompleteLabel title={group.label} />
+                  <AutocompleteCollection>
+                    {(item: string) => (
+                      <AutocompleteItem
+                        key={item}
+                        value={item}
+                        label={item}
+                        icon={group.icon}
+                      >
+                        <MenuItemAction className="text-xs text-muted">
+                          {group.label.slice(0, -1)}
+                        </MenuItemAction>
+                      </AutocompleteItem>
+                    )}
+                  </AutocompleteCollection>
+                </AutocompleteGroup>
+              )}
+            </AutocompleteList>
+          </AutocompleteContent>
+        </Autocomplete>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/registry/src/autocomplete-popover/index.ts
+++ b/packages/registry/src/autocomplete-popover/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./autocomplete-popover";

--- a/packages/registry/src/command-dialog/command-dialog.tsx
+++ b/packages/registry/src/command-dialog/command-dialog.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+
+import { Icon } from "@notion-kit/icons";
+import {
+  Button,
+  CommandCollection,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  MenuItemAction,
+} from "@notion-kit/ui/primitives";
+
+const ACTIONS = [
+  {
+    value: "new-page",
+    label: "New page",
+    icon: <Icon.Plus className="size-4 fill-menu-icon" />,
+    section: "Create",
+    shortcut: "N",
+  },
+  {
+    value: "invite",
+    label: "Invite members",
+    icon: <Icon.InviteMemberSmall className="size-4 fill-menu-icon" />,
+    section: "Workspace",
+    shortcut: "I",
+  },
+  {
+    value: "archive",
+    label: "Archive page",
+    icon: <Icon.ArchiveBox className="size-4 fill-menu-icon" />,
+    section: "Page",
+    shortcut: "A",
+  },
+];
+
+export default function CommandDialogDemo() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open command</Button>
+      <CommandDialog
+        open={open}
+        onOpenChange={setOpen}
+        items={ACTIONS}
+        itemToStringValue={(action) => action.label}
+        title="Workspace command palette"
+      >
+        <CommandInput search clear placeholder="Search actions..." />
+        <CommandList>
+          <CommandGroup heading="Actions" items={ACTIONS}>
+            <CommandCollection>
+              {(action: (typeof ACTIONS)[number]) => (
+                <CommandItem
+                  key={action.value}
+                  value={action}
+                  label={action.label}
+                  icon={action.icon}
+                  onClick={() => setOpen(false)}
+                >
+                  <MenuItemAction className="flex items-center gap-2 text-xs text-muted">
+                    <span>{action.section}</span>
+                    <span>{action.shortcut}</span>
+                  </MenuItemAction>
+                </CommandItem>
+              )}
+            </CommandCollection>
+          </CommandGroup>
+          <CommandEmpty>No commands found.</CommandEmpty>
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+}

--- a/packages/registry/src/command-dialog/command-dialog.tsx
+++ b/packages/registry/src/command-dialog/command-dialog.tsx
@@ -44,7 +44,9 @@ export default function CommandDialogDemo() {
 
   return (
     <>
-      <Button onClick={() => setOpen(true)}>Open command</Button>
+      <Button size="sm" onClick={() => setOpen(true)}>
+        Open command
+      </Button>
       <CommandDialog
         open={open}
         onOpenChange={setOpen}
@@ -54,7 +56,7 @@ export default function CommandDialogDemo() {
       >
         <CommandInput search clear placeholder="Search actions..." />
         <CommandList>
-          <CommandGroup heading="Actions" items={ACTIONS}>
+          <CommandGroup heading="Actions">
             <CommandCollection>
               {(action: (typeof ACTIONS)[number]) => (
                 <CommandItem

--- a/packages/registry/src/command-dialog/index.ts
+++ b/packages/registry/src/command-dialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./command-dialog";

--- a/packages/table-view/src/__tests__/mock.ts
+++ b/packages/table-view/src/__tests__/mock.ts
@@ -81,7 +81,7 @@ export function mockResizeObserver() {
 
   beforeEach(() => {
     global.ResizeObserver = ResizeObserverMock;
-    // Mock scrollIntoView for cmdk
+    // Mock scrollIntoView for menu primitives
     Element.prototype.scrollIntoView = vi.fn();
     Object.defineProperty(window, "matchMedia", {
       writable: true,

--- a/packages/table-view/src/common/group-actions.tsx
+++ b/packages/table-view/src/common/group-actions.tsx
@@ -64,12 +64,12 @@ export function GroupActions({ className, row }: GroupActionsProps) {
             <DropdownMenuItem
               {...(row.getShouldShowGroupAggregates()
                 ? {
-                    Icon: <Icon.EyeHideInversePadded className="size-6" />,
-                    Body: "Hide aggregation",
+                    icon: <Icon.EyeHideInversePadded className="size-6" />,
+                    label: "Hide aggregation",
                   }
                 : {
-                    Icon: <Icon.Eye />,
-                    Body: "Show aggregation",
+                    icon: <Icon.Eye />,
+                    label: "Show aggregation",
                   })}
               onClick={row.toggleGroupAggregates}
             />

--- a/packages/table-view/src/menus/prop-menu.tsx
+++ b/packages/table-view/src/menus/prop-menu.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { flexRender, functionalUpdate } from "@tanstack/react-table";
 
 import { Icon } from "@notion-kit/icons";
@@ -145,8 +143,8 @@ export function PropMenu({ propId, view }: PropMenuProps) {
               disabled={!canFreeze}
               onClick={pinColumns}
               {...(canUnfreeze
-                ? { Icon: <Icon.PinStrikeThrough />, Body: "Unfreeze columns" }
-                : { Icon: <Icon.Pin />, Body: "Freeze up to column" })}
+                ? { icon: <Icon.PinStrikeThrough />, label: "Unfreeze columns" }
+                : { icon: <Icon.Pin />, label: "Freeze up to column" })}
               className="[&_svg]:w-3"
             />
             {info.type !== "title" && (
@@ -159,8 +157,8 @@ export function PropMenu({ propId, view }: PropMenuProps) {
             <DropdownMenuItem
               onClick={wrapProp}
               {...(info.wrapped
-                ? { Icon: <Icon.ArrowLineRight />, Body: "Unwrap text" }
-                : { Icon: <Icon.ArrowUTurnDownLeft />, Body: "Wrap text" })}
+                ? { icon: <Icon.ArrowLineRight />, label: "Unwrap text" }
+                : { icon: <Icon.ArrowUTurnDownLeft />, label: "Wrap text" })}
             />
           </DropdownMenuGroup>
         </>

--- a/packages/table-view/src/menus/row-action-menu.tsx
+++ b/packages/table-view/src/menus/row-action-menu.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { useCopyToClipboard } from "@notion-kit/hooks";
@@ -16,7 +14,6 @@ import {
   AutocompleteLabel,
   AutocompleteList,
   AutocompleteSeparator,
-  MenuItem,
   MenuItemShortcut,
 } from "@notion-kit/ui/primitives";
 import { KEYBOARD } from "@notion-kit/utils";

--- a/packages/table-view/src/menus/row-action-menu.tsx
+++ b/packages/table-view/src/menus/row-action-menu.tsx
@@ -137,14 +137,14 @@ export function RowActionMenu({ rowId }: RowActionMenuProps) {
               onRemove={removeIcon}
               onUpload={uploadIcon}
             >
-              <MenuItem
+              <AutocompleteItem
                 icon={<Icon.EmojiFace className="size-5" />}
                 label="Edit icon"
               />
             </IconMenu>
           </AutocompleteGroup>
           <AutocompleteSeparator />
-          <AutocompleteGroup items={actions}>
+          <AutocompleteGroup>
             <AutocompleteCollection>
               {(action: (typeof actions)[number]) => (
                 <AutocompleteItem

--- a/packages/table-view/src/menus/row-action-menu.tsx
+++ b/packages/table-view/src/menus/row-action-menu.tsx
@@ -7,12 +7,15 @@ import { Icon } from "@notion-kit/icons";
 import type { IconData } from "@notion-kit/ui/icon-block";
 import { IconMenu } from "@notion-kit/ui/icon-menu";
 import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteLabel,
+  AutocompleteList,
+  AutocompleteSeparator,
   MenuItem,
   MenuItemShortcut,
 } from "@notion-kit/ui/primitives";
@@ -116,40 +119,50 @@ export function RowActionMenu({ rowId }: RowActionMenuProps) {
   useHotkeys("backspace", deleteRow);
 
   return (
-    <Command shouldFilter>
-      <CommandInput placeholder="Search actions..." />
-      <CommandList>
-        <CommandGroup heading="Page">
-          <IconMenu
-            className="w-full border-none text-start hover:bg-transparent"
-            onSelect={selectIcon}
-            onRemove={removeIcon}
-            onUpload={uploadIcon}
-          >
-            <MenuItem
-              icon={<Icon.EmojiFace className="size-5" />}
-              label="Edit icon"
-            />
-          </IconMenu>
-        </CommandGroup>
-        <CommandSeparator />
-        <CommandGroup>
-          {actions.map((prop) => (
-            <CommandItem
-              asChild
-              key={prop.value}
-              value={prop.value}
-              onSelect={prop.onSelect}
+    <Autocomplete
+      items={actions}
+      itemToStringValue={(action) => action.name}
+      open
+      autoHighlight="always"
+      openOnInputClick
+    >
+      <AutocompleteInput placeholder="Search actions..." />
+      <AutocompleteContent role="presentation" variant="inline">
+        <AutocompleteList>
+          <AutocompleteGroup>
+            <AutocompleteLabel title="Page" />
+            <IconMenu
+              className="w-full border-none text-start hover:bg-transparent"
+              onSelect={selectIcon}
+              onRemove={removeIcon}
+              onUpload={uploadIcon}
             >
-              <MenuItem icon={prop.icon} label={prop.name}>
-                {prop.shortcut && (
-                  <MenuItemShortcut>{prop.shortcut}</MenuItemShortcut>
-                )}
-              </MenuItem>
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      </CommandList>
-    </Command>
+              <MenuItem
+                icon={<Icon.EmojiFace className="size-5" />}
+                label="Edit icon"
+              />
+            </IconMenu>
+          </AutocompleteGroup>
+          <AutocompleteSeparator />
+          <AutocompleteGroup items={actions}>
+            <AutocompleteCollection>
+              {(action: (typeof actions)[number]) => (
+                <AutocompleteItem
+                  key={action.value}
+                  value={action}
+                  icon={action.icon}
+                  label={action.name}
+                  onClick={action.onSelect}
+                >
+                  {action.shortcut && (
+                    <MenuItemShortcut>{action.shortcut}</MenuItemShortcut>
+                  )}
+                </AutocompleteItem>
+              )}
+            </AutocompleteCollection>
+          </AutocompleteGroup>
+        </AutocompleteList>
+      </AutocompleteContent>
+    </Autocomplete>
   );
 }

--- a/packages/table-view/src/menus/select-group-menu.tsx
+++ b/packages/table-view/src/menus/select-group-menu.tsx
@@ -2,13 +2,14 @@
 
 import { IconBlock } from "@notion-kit/ui/icon-block";
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  MenuItem,
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteEmpty,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteList,
   MenuItemCheck,
 } from "@notion-kit/ui/primitives";
 
@@ -36,6 +37,12 @@ export function SelectGroupMenu() {
       page: TableViewMenuPage.EditGroupBy,
     });
   };
+  const groupOptions = [
+    ...(tableGlobal.layout !== "board"
+      ? [{ kind: "none" as const, id: null, name: "None" }]
+      : []),
+    ...options.map((option) => ({ kind: "column" as const, ...option })),
+  ];
 
   return (
     <>
@@ -48,45 +55,50 @@ export function SelectGroupMenu() {
           })
         }
       />
-      <Command shouldFilter>
-        <CommandInput placeholder="Search for a property" />
-        <CommandList>
-          <CommandGroup className="h-40 overflow-y-auto">
-            {tableGlobal.layout !== "board" && (
-              <CommandItem value="none" asChild>
-                <MenuItem label="None" onClick={() => selectGroup(null)}>
-                  {groupingColId === undefined && <MenuItemCheck />}
-                </MenuItem>
-              </CommandItem>
-            )}
-            {options.map(({ id, name, type, icon }) => (
-              <CommandItem
-                key={id}
-                value={name}
-                onSelect={() => selectGroup(id)}
-                asChild
-              >
-                <MenuItem
-                  key={id}
-                  icon={
-                    icon ? (
-                      <IconBlock icon={icon} />
-                    ) : (
-                      <DefaultIcon type={type} />
-                    )
-                  }
-                  label={name}
-                >
-                  {groupingColId === id && <MenuItemCheck />}
-                </MenuItem>
-              </CommandItem>
-            ))}
-          </CommandGroup>
-          <CommandEmpty className="px-3 text-start text-muted">
-            No results
-          </CommandEmpty>
-        </CommandList>
-      </Command>
+      <Autocomplete
+        items={groupOptions}
+        itemToStringValue={(option) => option.name}
+        open
+        autoHighlight="always"
+        openOnInputClick
+      >
+        <AutocompleteInput placeholder="Search for a property" />
+        <AutocompleteContent role="presentation" variant="inline">
+          <AutocompleteList>
+            <AutocompleteGroup
+              className="h-40 overflow-y-auto"
+              items={groupOptions}
+            >
+              <AutocompleteCollection>
+                {(option: (typeof groupOptions)[number]) => (
+                  <AutocompleteItem
+                    key={option.id ?? "none"}
+                    value={option}
+                    label={option.name}
+                    icon={
+                      option.kind === "column" ? (
+                        option.icon ? (
+                          <IconBlock icon={option.icon} />
+                        ) : (
+                          <DefaultIcon type={option.type} />
+                        )
+                      ) : null
+                    }
+                    onClick={() => selectGroup(option.id)}
+                  >
+                    {groupingColId === (option.id ?? undefined) && (
+                      <MenuItemCheck />
+                    )}
+                  </AutocompleteItem>
+                )}
+              </AutocompleteCollection>
+            </AutocompleteGroup>
+            <AutocompleteEmpty className="px-3 text-start text-muted">
+              No results
+            </AutocompleteEmpty>
+          </AutocompleteList>
+        </AutocompleteContent>
+      </Autocomplete>
     </>
   );
 }

--- a/packages/table-view/src/menus/select-group-menu.tsx
+++ b/packages/table-view/src/menus/select-group-menu.tsx
@@ -23,12 +23,21 @@ export function SelectGroupMenu() {
   const { columnOrder, columnsInfo, grouping, tableGlobal } = table.getState();
   const groupingColId = grouping.at(0);
 
-  const options = columnOrder.reduce<ColumnInfo[]>((acc, colId) => {
-    const col = columnsInfo[colId]!;
-    if (col.hidden || col.isDeleted) return acc;
-    acc.push(col);
-    return acc;
-  }, []);
+  const options = columnOrder.reduce<(ColumnInfo & { kind: "column" })[]>(
+    (acc, colId) => {
+      const col = columnsInfo[colId]!;
+      if (col.hidden || col.isDeleted) return acc;
+      acc.push({ ...col, kind: "column" });
+      return acc;
+    },
+    [],
+  );
+  const groupOptions = [
+    ...(tableGlobal.layout !== "board"
+      ? [{ kind: "none" as const, id: null, name: "None" }]
+      : []),
+    ...options,
+  ];
 
   const selectGroup = (colId: string | null) => {
     table.setGroupingColumn(colId);
@@ -37,12 +46,6 @@ export function SelectGroupMenu() {
       page: TableViewMenuPage.EditGroupBy,
     });
   };
-  const groupOptions = [
-    ...(tableGlobal.layout !== "board"
-      ? [{ kind: "none" as const, id: null, name: "None" }]
-      : []),
-    ...options.map((option) => ({ kind: "column" as const, ...option })),
-  ];
 
   return (
     <>
@@ -65,10 +68,7 @@ export function SelectGroupMenu() {
         <AutocompleteInput placeholder="Search for a property" />
         <AutocompleteContent role="presentation" variant="inline">
           <AutocompleteList>
-            <AutocompleteGroup
-              className="h-40 overflow-y-auto"
-              items={groupOptions}
-            >
+            <AutocompleteGroup className="h-40">
               <AutocompleteCollection>
                 {(option: (typeof groupOptions)[number]) => (
                   <AutocompleteItem
@@ -93,10 +93,10 @@ export function SelectGroupMenu() {
                 )}
               </AutocompleteCollection>
             </AutocompleteGroup>
-            <AutocompleteEmpty className="px-3 text-start text-muted">
-              No results
-            </AutocompleteEmpty>
           </AutocompleteList>
+          <AutocompleteEmpty className="px-3 text-start text-muted">
+            No results
+          </AutocompleteEmpty>
         </AutocompleteContent>
       </Autocomplete>
     </>

--- a/packages/table-view/src/menus/sort-menu.tsx
+++ b/packages/table-view/src/menus/sort-menu.tsx
@@ -218,7 +218,7 @@ function PropSelectMenu() {
       <AutocompleteInput clear placeholder="Search for a property..." />
       <AutocompleteContent role="presentation" variant="inline">
         <AutocompleteList>
-          <AutocompleteGroup className="h-40 overflow-y-auto" items={columns}>
+          <AutocompleteGroup className="h-40 overflow-y-auto">
             <AutocompleteCollection>
               {(column: (typeof columns)[number]) => (
                 <AutocompleteItem
@@ -238,10 +238,10 @@ function PropSelectMenu() {
               )}
             </AutocompleteCollection>
           </AutocompleteGroup>
-          <AutocompleteEmpty className="px-3 text-start text-muted">
-            No results
-          </AutocompleteEmpty>
         </AutocompleteList>
+        <AutocompleteEmpty className="px-3 text-start text-muted">
+          No results
+        </AutocompleteEmpty>
       </AutocompleteContent>
     </Autocomplete>
   );

--- a/packages/table-view/src/menus/sort-menu.tsx
+++ b/packages/table-view/src/menus/sort-menu.tsx
@@ -8,13 +8,15 @@ import type { ColumnSort } from "@tanstack/react-table";
 import { Icon } from "@notion-kit/icons";
 import { IconBlock } from "@notion-kit/ui/icon-block";
 import {
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteEmpty,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteList,
   Button,
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
   MenuGroup,
   MenuItem,
   MenuItemAction,
@@ -206,32 +208,41 @@ function PropSelectMenu() {
     table.setSorting((prev) => [...prev, { id, desc: false }]);
 
   return (
-    <Command shouldFilter>
-      <CommandInput clear placeholder="Search for a property..." />
-      <CommandList>
-        <CommandGroup className="h-40 overflow-y-auto">
-          {columns.map(({ id, name, type, icon }) => (
-            <CommandItem
-              key={id}
-              value={name}
-              onSelect={() => selectProp(id)}
-              disabled={sortedProps.has(id)}
-              asChild
-            >
-              <MenuItem
-                key={id}
-                icon={
-                  icon ? <IconBlock icon={icon} /> : <DefaultIcon type={type} />
-                }
-                label={name}
-              />
-            </CommandItem>
-          ))}
-        </CommandGroup>
-        <CommandEmpty className="px-3 text-start text-muted">
-          No results
-        </CommandEmpty>
-      </CommandList>
-    </Command>
+    <Autocomplete
+      items={columns}
+      itemToStringValue={(column) => column.name}
+      open
+      autoHighlight="always"
+      openOnInputClick
+    >
+      <AutocompleteInput clear placeholder="Search for a property..." />
+      <AutocompleteContent role="presentation" variant="inline">
+        <AutocompleteList>
+          <AutocompleteGroup className="h-40 overflow-y-auto" items={columns}>
+            <AutocompleteCollection>
+              {(column: (typeof columns)[number]) => (
+                <AutocompleteItem
+                  key={column.id}
+                  value={column}
+                  onClick={() => selectProp(column.id)}
+                  disabled={sortedProps.has(column.id)}
+                  icon={
+                    column.icon ? (
+                      <IconBlock icon={column.icon} />
+                    ) : (
+                      <DefaultIcon type={column.type} />
+                    )
+                  }
+                  label={column.name}
+                />
+              )}
+            </AutocompleteCollection>
+          </AutocompleteGroup>
+          <AutocompleteEmpty className="px-3 text-start text-muted">
+            No results
+          </AutocompleteEmpty>
+        </AutocompleteList>
+      </AutocompleteContent>
+    </Autocomplete>
   );
 }

--- a/packages/table-view/src/menus/table-view-menu.tsx
+++ b/packages/table-view/src/menus/table-view-menu.tsx
@@ -111,7 +111,7 @@ function TableMenu() {
         <MenuItem
           icon={<Icon.Sliders />}
           label="Edit properties"
-          data-disabled={locked}
+          aria-disabled={locked}
           onClick={() => openMenu(TableViewMenuPage.Props)}
         >
           <MenuItemSelect />

--- a/packages/table-view/src/menus/types-menu.tsx
+++ b/packages/table-view/src/menus/types-menu.tsx
@@ -1,16 +1,17 @@
 "use client";
 
+import { useState } from "react";
 import { v4 } from "uuid";
 
-import { cn } from "@notion-kit/cn";
-import { useFilter } from "@notion-kit/hooks";
 import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  MenuItem,
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteLabel,
+  AutocompleteList,
   MenuItemCheck,
   TooltipPreset,
 } from "@notion-kit/ui/primitives";
@@ -49,12 +50,10 @@ export function TypesMenu({ propId, at, menu, back }: TypesMenuProps) {
   const { table } = useTableViewCtx();
 
   const plugins = table.getState().cellPlugins;
+  const pluginOptions = Object.values(plugins);
   const propType = propId ? table.getColumnInfo(propId).type : null;
+  const [search, setSearch] = useState("");
 
-  const { search, results, updateSearch } = useFilter(
-    Object.values(plugins),
-    (prop, v) => prop.default.name.toLowerCase().includes(v),
-  );
   const select = (type: PluginType<CellPlugin[]>, name: string) => {
     let colId = propId;
     if (colId === undefined) {
@@ -95,67 +94,65 @@ export function TypesMenu({ propId, at, menu, back }: TypesMenuProps) {
           }
         />
       )}
-      <Command shouldFilter={false}>
-        <CommandInput
-          value={search}
-          onValueChange={updateSearch}
+      <Autocomplete
+        items={pluginOptions}
+        itemToStringValue={(plugin) => plugin.default.name}
+        value={search}
+        onValueChange={setSearch}
+        open
+        autoHighlight="always"
+        openOnInputClick
+      >
+        <AutocompleteInput
           placeholder={
             propId ? "Search for property type" : "Search or add new property"
           }
         />
-        <CommandList>
-          {results && results.length > 0 && (
-            <CommandGroup
-              className={cn(
-                "flex flex-col gap-px px-0",
-                "**:[[cmdk-group-heading]]:mt-1.5 **:[[cmdk-group-heading]]:mb-2 **:[[cmdk-group-heading]]:flex **:[[cmdk-group-heading]]:items-center **:[[cmdk-group-heading]]:truncate **:[[cmdk-group-heading]]:px-3.5 **:[[cmdk-group-heading]]:py-0 **:[[cmdk-group-heading]]:leading-tight **:[[cmdk-group-heading]]:text-secondary **:[[cmdk-group-heading]]:select-none",
-              )}
-              heading="Type"
+        <AutocompleteContent role="presentation" variant="inline">
+          <AutocompleteList>
+            <AutocompleteGroup
+              className="flex flex-col gap-px px-0"
+              items={pluginOptions}
             >
-              {results.map(({ id, meta }) => (
-                <CommandItem key={id} value={`default-${id}`} asChild>
+              <AutocompleteLabel title="Type" />
+              <AutocompleteCollection>
+                {(plugin: (typeof pluginOptions)[number]) => (
                   <TooltipPreset
+                    key={plugin.id}
                     side="left"
                     sideOffset={6}
-                    description={meta.desc}
-                    // WARNING adding `text-xs/[1.4] to prevent style overriding by `CommandItem`
+                    description={plugin.meta.desc}
                     className="max-w-[282px] text-xs/[1.4]"
                   >
-                    <MenuItem
-                      aria-disabled={id === "title"}
-                      icon={meta.icon}
-                      label={meta.name}
-                      onClick={() => select(id, meta.name)}
+                    <AutocompleteItem
+                      value={plugin}
+                      disabled={plugin.id === "title"}
+                      icon={plugin.meta.icon}
+                      label={plugin.meta.name}
+                      onClick={() => select(plugin.id, plugin.meta.name)}
                     >
-                      {propType === id && <MenuItemCheck />}
-                    </MenuItem>
+                      {propType === plugin.id && <MenuItemCheck />}
+                    </AutocompleteItem>
                   </TooltipPreset>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          )}
-          {!propId && search.length > 0 && (
-            <CommandGroup
-              className={cn(
-                "flex flex-col gap-px px-0",
-                "**:[[cmdk-group-heading]]:mt-1.5 **:[[cmdk-group-heading]]:mb-2 **:[[cmdk-group-heading]]:flex **:[[cmdk-group-heading]]:items-center **:[[cmdk-group-heading]]:truncate **:[[cmdk-group-heading]]:px-3.5 **:[[cmdk-group-heading]]:py-0 **:[[cmdk-group-heading]]:leading-tight **:[[cmdk-group-heading]]:text-secondary **:[[cmdk-group-heading]]:select-none",
-              )}
-              heading="Select to add"
-            >
-              <CommandItem
-                value={`search-${search}`}
-                onSelect={() => select("text", search)}
-                asChild
+                )}
+              </AutocompleteCollection>
+            </AutocompleteGroup>
+            {!propId && search.length > 0 && (
+              <AutocompleteGroup
+                className="flex flex-col gap-px px-0"
               >
-                <MenuItem
+                <AutocompleteLabel title="Select to add" />
+                <AutocompleteItem
+                  value={`search-${search}`}
                   icon={<DefaultIcon type="text" className="fill-menu-icon" />}
                   label={search}
+                  onClick={() => select("text", search)}
                 />
-              </CommandItem>
-            </CommandGroup>
-          )}
-        </CommandList>
-      </Command>
+              </AutocompleteGroup>
+            )}
+          </AutocompleteList>
+        </AutocompleteContent>
+      </Autocomplete>
     </>
   );
 }

--- a/packages/table-view/src/menus/types-menu.tsx
+++ b/packages/table-view/src/menus/types-menu.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useState } from "react";
 import { v4 } from "uuid";
 
@@ -19,7 +17,7 @@ import {
 import { DefaultIcon, MenuHeader } from "../common";
 import { TableViewMenuPage } from "../features";
 import type { PluginType } from "../lib/types";
-import { CellPlugin } from "../plugins";
+import type { CellPlugin } from "../plugins";
 import { useTableViewCtx } from "../table-contexts";
 
 interface TypesMenuProps {
@@ -110,13 +108,10 @@ export function TypesMenu({ propId, at, menu, back }: TypesMenuProps) {
         />
         <AutocompleteContent role="presentation" variant="inline">
           <AutocompleteList>
-            <AutocompleteGroup
-              className="flex flex-col gap-px px-0"
-              items={pluginOptions}
-            >
+            <AutocompleteGroup>
               <AutocompleteLabel title="Type" />
               <AutocompleteCollection>
-                {(plugin: (typeof pluginOptions)[number]) => (
+                {(plugin: CellPlugin) => (
                   <TooltipPreset
                     key={plugin.id}
                     side="left"
@@ -138,9 +133,7 @@ export function TypesMenu({ propId, at, menu, back }: TypesMenuProps) {
               </AutocompleteCollection>
             </AutocompleteGroup>
             {!propId && search.length > 0 && (
-              <AutocompleteGroup
-                className="flex flex-col gap-px px-0"
-              >
+              <AutocompleteGroup>
                 <AutocompleteLabel title="Select to add" />
                 <AutocompleteItem
                   value={`search-${search}`}

--- a/packages/table-view/src/table-header/table-header-cell.tsx
+++ b/packages/table-view/src/table-header/table-header-cell.tsx
@@ -119,7 +119,7 @@ export function TableHeaderCell({
           role="presentation"
           tabIndex={-1}
           className={cn(
-            "-mt-px -ml-[3px] h-[34px] w-[5px] animate-bg-out cursor-col-resize bg-transparent hover:bg-blue/80",
+            "-mt-px ml-[-3px] h-[34px] w-[5px] animate-bg-out cursor-col-resize bg-transparent hover:bg-blue/80",
             isResizing && "bg-blue/80",
           )}
           // Resize for desktop

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -51,7 +51,6 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@tanstack/react-virtual": "catalog:ui",
     "@uidotdev/usehooks": "^2.4.1",
-    "cmdk": "^1.1.1",
     "date-fns": "catalog:fns",
     "i18next": "^25.0.1",
     "jotai": "^2.19.0",

--- a/packages/ui/src/primitives/autocomplete.test.tsx
+++ b/packages/ui/src/primitives/autocomplete.test.tsx
@@ -56,9 +56,10 @@ describe("Autocomplete", () => {
       "data-slot",
       "autocomplete-label",
     );
-    expect(
-      screen.getByRole("option", { name: "Components" }),
-    ).toHaveAttribute("data-slot", "autocomplete-item");
+    expect(screen.getByRole("option", { name: "Components" })).toHaveAttribute(
+      "data-slot",
+      "autocomplete-item",
+    );
   });
 
   it("shows empty state through Base UI filtering", async () => {

--- a/packages/ui/src/primitives/autocomplete.test.tsx
+++ b/packages/ui/src/primitives/autocomplete.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteEmpty,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteLabel,
+  AutocompleteList,
+  AutocompleteSeparator,
+} from "./autocomplete";
+
+const groups = [
+  {
+    value: "Pages",
+    items: ["Getting Started", "Components"],
+  },
+  {
+    value: "Actions",
+    items: ["Invite Members", "Archive Page"],
+  },
+];
+
+describe("Autocomplete", () => {
+  it("renders grouped items with menu visuals", () => {
+    render(
+      <Autocomplete items={groups} defaultOpen openOnInputClick>
+        <AutocompleteInput aria-label="Search workspace" />
+        <AutocompleteContent variant="inline">
+          <AutocompleteList>
+            {(group: (typeof groups)[number]) => (
+              <AutocompleteGroup key={group.value} items={group.items}>
+                <AutocompleteLabel title={group.value} />
+                <AutocompleteCollection>
+                  {(item: string) => (
+                    <AutocompleteItem key={item} value={item} label={item} />
+                  )}
+                </AutocompleteCollection>
+              </AutocompleteGroup>
+            )}
+          </AutocompleteList>
+        </AutocompleteContent>
+      </Autocomplete>,
+    );
+
+    expect(
+      screen.getByRole("combobox", { name: "Search workspace" }),
+    ).toHaveAttribute("data-slot", "autocomplete-input");
+    expect(screen.getAllByRole("group")).toHaveLength(2);
+    expect(screen.getByText("Pages").closest("[data-slot]")).toHaveAttribute(
+      "data-slot",
+      "autocomplete-label",
+    );
+    expect(
+      screen.getByRole("option", { name: "Components" }),
+    ).toHaveAttribute("data-slot", "autocomplete-item");
+  });
+
+  it("shows empty state through Base UI filtering", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Autocomplete items={groups} defaultOpen openOnInputClick>
+        <AutocompleteInput aria-label="Search workspace" />
+        <AutocompleteContent variant="inline">
+          <AutocompleteEmpty>No matches</AutocompleteEmpty>
+          <AutocompleteList>
+            {(group: (typeof groups)[number]) => (
+              <AutocompleteGroup key={group.value} items={group.items}>
+                <AutocompleteLabel title={group.value} />
+                <AutocompleteCollection>
+                  {(item: string) => (
+                    <AutocompleteItem key={item} value={item} label={item} />
+                  )}
+                </AutocompleteCollection>
+              </AutocompleteGroup>
+            )}
+          </AutocompleteList>
+        </AutocompleteContent>
+      </Autocomplete>,
+    );
+
+    await user.type(
+      screen.getByRole("combobox", { name: "Search workspace" }),
+      "zzzzz",
+    );
+
+    expect(screen.getByText("No matches")).toBeVisible();
+  });
+
+  it("activates an item with keyboard selection", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(
+      <Autocomplete items={["Archive Page"]} defaultOpen autoHighlight="always">
+        <AutocompleteInput aria-label="Search actions" />
+        <AutocompleteContent variant="inline">
+          <AutocompleteList>
+            <AutocompleteGroup>
+              <AutocompleteItem
+                value="Archive Page"
+                label="Archive Page"
+                onClick={onSelect}
+              />
+            </AutocompleteGroup>
+          </AutocompleteList>
+        </AutocompleteContent>
+      </Autocomplete>,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Search actions" }));
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders separators with the shared separator slot", () => {
+    render(
+      <Autocomplete items={["Archive Page"]} defaultOpen>
+        <AutocompleteInput aria-label="Search actions" />
+        <AutocompleteContent variant="inline">
+          <AutocompleteList>
+            <AutocompleteGroup>
+              <AutocompleteItem value="Archive Page" label="Archive Page" />
+            </AutocompleteGroup>
+            <AutocompleteSeparator />
+            <AutocompleteGroup>
+              <AutocompleteItem value="Delete Page" label="Delete Page" />
+            </AutocompleteGroup>
+          </AutocompleteList>
+        </AutocompleteContent>
+      </Autocomplete>,
+    );
+
+    const separator = screen.getByRole("separator");
+    expect(separator).toHaveAttribute("data-slot", "autocomplete-separator");
+  });
+
+  it("keeps items inside an autocomplete group", () => {
+    render(
+      <Autocomplete items={["Archive Page"]} defaultOpen>
+        <AutocompleteInput aria-label="Search actions" />
+        <AutocompleteContent variant="inline">
+          <AutocompleteList>
+            <AutocompleteGroup>
+              <AutocompleteItem value="Archive Page" label="Archive Page" />
+            </AutocompleteGroup>
+          </AutocompleteList>
+        </AutocompleteContent>
+      </Autocomplete>,
+    );
+
+    const group = screen.getByRole("group");
+    expect(
+      within(group).getByRole("option", { name: "Archive Page" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/primitives/autocomplete.tsx
+++ b/packages/ui/src/primitives/autocomplete.tsx
@@ -50,10 +50,10 @@ type AutocompleteInputProps = Omit<
   keyof InputProps | "render"
 > &
   Omit<InputProps, "onChange" | "value" | "defaultValue"> & {
-  classNames?: {
-    wrapper?: string;
+    classNames?: {
+      wrapper?: string;
+    };
   };
-};
 
 function AutocompleteInput({
   className,
@@ -145,44 +145,20 @@ function AutocompleteContent({
   alignOffset,
   anchor,
   collisionPadding,
+  style,
   ...props
 }: AutocompleteContentProps) {
-  const [inlineContainer, setInlineContainer] =
-    React.useState<HTMLDivElement | null>(null);
-
   if (variant === "inline") {
     return (
-      <>
-        <div ref={setInlineContainer} className="relative z-10 w-full" />
-        {inlineContainer && (
-          <AutocompletePrimitive.Portal container={inlineContainer}>
-            <AutocompletePrimitive.Positioner
-              align={align}
-              alignOffset={alignOffset}
-              anchor={anchor}
-              collisionPadding={collisionPadding}
-              side={side}
-              sideOffset={sideOffset}
-              className="relative w-full"
-              style={{
-                position: "relative",
-                inset: "auto",
-                transform: "none",
-              }}
-            >
-              <AutocompletePrimitive.Popup
-                data-slot="autocomplete-content"
-                data-variant={variant}
-                className={cn(
-                  "group/autocomplete-content relative w-full overflow-hidden rounded-md bg-modal",
-                  className,
-                )}
-                {...props}
-              />
-            </AutocompletePrimitive.Positioner>
-          </AutocompletePrimitive.Portal>
+      <div
+        data-slot="autocomplete-content"
+        data-variant={variant}
+        className={cn(
+          "group/autocomplete-content relative w-full overflow-hidden",
+          className,
         )}
-      </>
+        {...props}
+      />
     );
   }
 
@@ -200,9 +176,10 @@ function AutocompleteContent({
         <AutocompletePrimitive.Popup
           data-slot="autocomplete-content"
           data-variant={variant}
+          style={style}
           className={cn(
-            contentVariants({ variant: "default", openAnimation: true }),
-            "group/autocomplete-content max-h-[min(calc(var(--available-height)-8px),300px)] w-(--anchor-width) min-w-(--anchor-width) overflow-hidden rounded-md bg-modal",
+            contentVariants({ variant: "popover", openAnimation: true }),
+            "group/autocomplete-content max-h-[min(calc(var(--available-height)-8px),300px)] w-(--anchor-width) min-w-(--anchor-width) overflow-hidden",
             className,
           )}
           {...props}
@@ -240,11 +217,8 @@ function AutocompleteGroup({
 }
 
 interface AutocompleteLabelProps
-  extends Omit<
-    AutocompletePrimitive.GroupLabel.Props,
-    "children" | "render" | "title"
-  > {
-  title: React.ReactNode;
+  extends AutocompletePrimitive.GroupLabel.Props {
+  title: string;
 }
 
 function AutocompleteLabel({ title, ...props }: AutocompleteLabelProps) {
@@ -278,7 +252,6 @@ function AutocompleteItem<ItemValue = string>({
   label,
   desc,
   variant,
-  children,
   ...props
 }: AutocompleteItemProps<ItemValue>) {
   return (
@@ -295,9 +268,7 @@ function AutocompleteItem<ItemValue = string>({
         />
       }
       {...props}
-    >
-      {children}
-    </AutocompletePrimitive.Item>
+    />
   );
 }
 
@@ -322,7 +293,8 @@ function AutocompleteEmpty({
     <AutocompletePrimitive.Empty
       data-slot="autocomplete-empty"
       className={cn(
-        "min-h-7 items-center p-2 text-sm/tight text-secondary select-none",
+        "hidden min-h-7 items-center p-2 text-sm/tight text-secondary select-none",
+        "group-data-empty/autocomplete-content:flex",
         className,
       )}
       {...props}

--- a/packages/ui/src/primitives/autocomplete.tsx
+++ b/packages/ui/src/primitives/autocomplete.tsx
@@ -1,0 +1,379 @@
+import * as React from "react";
+import { Autocomplete as AutocompletePrimitive } from "@base-ui/react/autocomplete";
+
+import { cn } from "@notion-kit/cn";
+import { Icon } from "@notion-kit/icons";
+
+import { Button } from "./button";
+import * as _Icon from "./icons";
+import { Input, type InputProps } from "./input";
+import { MenuGroup, MenuItem, MenuLabel } from "./menu";
+import { Separator } from "./separator";
+import { contentVariants } from "./variants";
+
+type AutocompleteGroupItem<ItemValue> = {
+  items: readonly ItemValue[];
+};
+
+type AutocompleteRootProps<ItemValue = string> = Omit<
+  AutocompletePrimitive.Root.Props<ItemValue>,
+  "items"
+> & {
+  items?: readonly ItemValue[] | readonly AutocompleteGroupItem<ItemValue>[];
+};
+
+function Autocomplete<ItemValue = string>({
+  ...props
+}: AutocompleteRootProps<ItemValue>) {
+  const Root = AutocompletePrimitive.Root as React.ComponentType<
+    AutocompleteRootProps<ItemValue>
+  >;
+
+  return <Root {...props} />;
+}
+
+function AutocompleteInputGroup({
+  className,
+  ...props
+}: AutocompletePrimitive.InputGroup.Props) {
+  return (
+    <AutocompletePrimitive.InputGroup
+      data-slot="autocomplete-input-group"
+      className={cn("flex min-w-0 items-center", className)}
+      {...props}
+    />
+  );
+}
+
+type AutocompleteInputProps = Omit<
+  AutocompletePrimitive.Input.Props,
+  keyof InputProps | "render"
+> &
+  Omit<InputProps, "onChange" | "value" | "defaultValue"> & {
+  classNames?: {
+    wrapper?: string;
+  };
+};
+
+function AutocompleteInput({
+  className,
+  classNames,
+  search,
+  clear,
+  onCancel,
+  ...props
+}: AutocompleteInputProps) {
+  return (
+    <div
+      data-slot="autocomplete-input-wrapper"
+      className={cn(
+        "flex min-w-0 flex-auto flex-col px-3 pt-3 pb-2",
+        classNames?.wrapper,
+      )}
+    >
+      <AutocompletePrimitive.Input
+        data-slot="autocomplete-input"
+        render={
+          <Input
+            className={className}
+            search={search}
+            clear={clear}
+            onCancel={onCancel}
+          />
+        }
+        {...props}
+      />
+    </div>
+  );
+}
+
+function AutocompleteTrigger({
+  className,
+  children,
+  ...props
+}: AutocompletePrimitive.Trigger.Props) {
+  return (
+    <AutocompletePrimitive.Trigger
+      data-slot="autocomplete-trigger"
+      className={cn(
+        "inline-flex items-center justify-center text-muted outline-none",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? <Icon.Chevron side="down" className="size-3.5 fill-icon" />}
+    </AutocompletePrimitive.Trigger>
+  );
+}
+
+function AutocompleteClear({ ...props }: AutocompletePrimitive.Clear.Props) {
+  return (
+    <AutocompletePrimitive.Clear
+      data-slot="autocomplete-clear"
+      render={
+        <Button type="button" variant="close" size="circle">
+          <_Icon.Clear />
+        </Button>
+      }
+      {...props}
+    />
+  );
+}
+
+type AutocompletePositionerProps = Pick<
+  AutocompletePrimitive.Positioner.Props,
+  | "align"
+  | "alignOffset"
+  | "anchor"
+  | "collisionPadding"
+  | "side"
+  | "sideOffset"
+>;
+
+interface AutocompleteContentProps
+  extends AutocompletePrimitive.Popup.Props,
+    AutocompletePositionerProps {
+  variant?: "floating" | "inline";
+}
+
+function AutocompleteContent({
+  className,
+  variant = "floating",
+  align = "start",
+  side = "bottom",
+  sideOffset = 4,
+  alignOffset,
+  anchor,
+  collisionPadding,
+  ...props
+}: AutocompleteContentProps) {
+  const [inlineContainer, setInlineContainer] =
+    React.useState<HTMLDivElement | null>(null);
+
+  if (variant === "inline") {
+    return (
+      <>
+        <div ref={setInlineContainer} className="relative z-10 w-full" />
+        {inlineContainer && (
+          <AutocompletePrimitive.Portal container={inlineContainer}>
+            <AutocompletePrimitive.Positioner
+              align={align}
+              alignOffset={alignOffset}
+              anchor={anchor}
+              collisionPadding={collisionPadding}
+              side={side}
+              sideOffset={sideOffset}
+              className="relative w-full"
+              style={{
+                position: "relative",
+                inset: "auto",
+                transform: "none",
+              }}
+            >
+              <AutocompletePrimitive.Popup
+                data-slot="autocomplete-content"
+                data-variant={variant}
+                className={cn(
+                  "group/autocomplete-content relative w-full overflow-hidden rounded-md bg-modal",
+                  className,
+                )}
+                {...props}
+              />
+            </AutocompletePrimitive.Positioner>
+          </AutocompletePrimitive.Portal>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <AutocompletePrimitive.Portal>
+      <AutocompletePrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        anchor={anchor}
+        collisionPadding={collisionPadding}
+        side={side}
+        sideOffset={sideOffset}
+        className="z-(--z-menu)"
+      >
+        <AutocompletePrimitive.Popup
+          data-slot="autocomplete-content"
+          data-variant={variant}
+          className={cn(
+            contentVariants({ variant: "default", openAnimation: true }),
+            "group/autocomplete-content max-h-[min(calc(var(--available-height)-8px),300px)] w-(--anchor-width) min-w-(--anchor-width) overflow-hidden rounded-md bg-modal",
+            className,
+          )}
+          {...props}
+        />
+      </AutocompletePrimitive.Positioner>
+    </AutocompletePrimitive.Portal>
+  );
+}
+
+function AutocompleteList({
+  className,
+  ...props
+}: AutocompletePrimitive.List.Props) {
+  return (
+    <AutocompletePrimitive.List
+      data-slot="autocomplete-list"
+      className={cn("max-h-75 overflow-auto overflow-x-hidden", className)}
+      {...props}
+    />
+  );
+}
+
+function AutocompleteGroup({
+  className,
+  ...props
+}: AutocompletePrimitive.Group.Props) {
+  return (
+    <AutocompletePrimitive.Group
+      data-slot="autocomplete-group"
+      render={<MenuGroup />}
+      className={cn("h-full overflow-auto", className)}
+      {...props}
+    />
+  );
+}
+
+interface AutocompleteLabelProps
+  extends Omit<
+    AutocompletePrimitive.GroupLabel.Props,
+    "children" | "render" | "title"
+  > {
+  title: React.ReactNode;
+}
+
+function AutocompleteLabel({ title, ...props }: AutocompleteLabelProps) {
+  return (
+    <AutocompletePrimitive.GroupLabel
+      data-slot="autocomplete-label"
+      render={<MenuLabel title={title} />}
+      {...props}
+    />
+  );
+}
+
+type AutocompleteItemVisualProps = Pick<
+  React.ComponentProps<typeof MenuItem>,
+  "className" | "desc" | "icon" | "label" | "variant"
+>;
+
+interface AutocompleteItemProps<ItemValue = string>
+  extends Omit<
+      AutocompletePrimitive.Item.Props,
+      "className" | "render" | "value"
+    >,
+    AutocompleteItemVisualProps {
+  value?: ItemValue;
+}
+
+function AutocompleteItem<ItemValue = string>({
+  className,
+  value,
+  icon,
+  label,
+  desc,
+  variant,
+  children,
+  ...props
+}: AutocompleteItemProps<ItemValue>) {
+  return (
+    <AutocompletePrimitive.Item
+      data-slot="autocomplete-item"
+      value={value}
+      render={
+        <MenuItem
+          className={className}
+          icon={icon}
+          label={label ?? String(value)}
+          desc={desc}
+          variant={variant}
+        />
+      }
+      {...props}
+    >
+      {children}
+    </AutocompletePrimitive.Item>
+  );
+}
+
+function AutocompleteSeparator({
+  className,
+  ...props
+}: AutocompletePrimitive.Separator.Props) {
+  return (
+    <AutocompletePrimitive.Separator
+      data-slot="autocomplete-separator"
+      render={<Separator className={className} />}
+      {...props}
+    />
+  );
+}
+
+function AutocompleteEmpty({
+  className,
+  ...props
+}: AutocompletePrimitive.Empty.Props) {
+  return (
+    <AutocompletePrimitive.Empty
+      data-slot="autocomplete-empty"
+      className={cn(
+        "min-h-7 items-center p-2 text-sm/tight text-secondary select-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AutocompleteStatus({
+  className,
+  ...props
+}: AutocompletePrimitive.Status.Props) {
+  return (
+    <AutocompletePrimitive.Status
+      data-slot="autocomplete-status"
+      className={cn("px-3 py-1 text-xs text-muted", className)}
+      {...props}
+    />
+  );
+}
+
+function AutocompleteCollection({
+  ...props
+}: AutocompletePrimitive.Collection.Props) {
+  return (
+    <AutocompletePrimitive.Collection
+      data-slot="autocomplete-collection"
+      {...props}
+    />
+  );
+}
+
+export {
+  Autocomplete,
+  AutocompleteClear,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteEmpty,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteInputGroup,
+  AutocompleteItem,
+  AutocompleteLabel,
+  AutocompleteList,
+  AutocompleteSeparator,
+  AutocompleteStatus,
+  AutocompleteTrigger,
+};
+export type {
+  AutocompleteContentProps,
+  AutocompleteInputProps,
+  AutocompleteItemProps,
+  AutocompleteLabelProps,
+  AutocompleteRootProps,
+};

--- a/packages/ui/src/primitives/autocomplete.tsx
+++ b/packages/ui/src/primitives/autocomplete.tsx
@@ -11,9 +11,9 @@ import { MenuGroup, MenuItem, MenuLabel } from "./menu";
 import { Separator } from "./separator";
 import { contentVariants } from "./variants";
 
-type AutocompleteGroupItem<ItemValue> = {
+interface AutocompleteGroupItem<ItemValue> {
   items: readonly ItemValue[];
-};
+}
 
 type AutocompleteRootProps<ItemValue = string> = Omit<
   AutocompletePrimitive.Root.Props<ItemValue>,

--- a/packages/ui/src/primitives/autocomplete.tsx
+++ b/packages/ui/src/primitives/autocomplete.tsx
@@ -217,8 +217,11 @@ function AutocompleteGroup({
 }
 
 interface AutocompleteLabelProps
-  extends AutocompletePrimitive.GroupLabel.Props {
-  title: string;
+  extends Omit<
+    AutocompletePrimitive.GroupLabel.Props,
+    "children" | "render" | "title"
+  > {
+  title: React.ReactNode;
 }
 
 function AutocompleteLabel({ title, ...props }: AutocompleteLabelProps) {

--- a/packages/ui/src/primitives/combobox.tsx
+++ b/packages/ui/src/primitives/combobox.tsx
@@ -24,6 +24,7 @@ function Combobox<Value, Multiple extends boolean | undefined = false>(
   const anchor = React.useRef<HTMLElement | null>(null);
   const ctx = React.useMemo<ComboboxAnchorContextValue>(
     () =>
+      // eslint-disable-next-line react-hooks/refs
       Object.assign(anchor, {
         ref: (node: HTMLElement | null) => {
           anchor.current = node;
@@ -206,12 +207,12 @@ function ComboboxItem({
   return (
     <ComboboxPrimitive.Item
       data-slot="combobox-item"
-      value={value}
+      value={value as unknown}
       render={
         <MenuItem
           className={className}
           icon={icon}
-          label={label ?? value}
+          label={label ?? String(value)}
           desc={desc}
         />
       }

--- a/packages/ui/src/primitives/command.test.tsx
+++ b/packages/ui/src/primitives/command.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandCollection,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "./command";
+
+describe("CommandDialog", () => {
+  it("renders an accessible command palette dialog", () => {
+    render(
+      <CommandDialog open title="Workspace command palette">
+        <CommandInput aria-label="Search commands" placeholder="Search..." />
+        <CommandList>
+          <CommandGroup heading="Actions">
+            <CommandItem value="archive" label="Archive">
+              <CommandShortcut>⌘A</CommandShortcut>
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Workspace command palette" }),
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getByText("Workspace command palette")
+        .closest("[data-slot='dialog-header']"),
+    ).toHaveClass("sr-only");
+    expect(
+      screen.getByRole("combobox", { name: "Search commands" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Archive" })).toBeInTheDocument();
+  });
+
+  it("filters commands through autocomplete internals", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CommandDialog open items={["archive", "duplicate"]}>
+        <CommandInput aria-label="Search commands" />
+        <CommandList>
+          <CommandGroup heading="Actions">
+            <CommandCollection>
+              {(item: string) => (
+                <CommandItem
+                  key={item}
+                  value={item}
+                  label={item === "archive" ? "Archive" : "Duplicate"}
+                />
+              )}
+            </CommandCollection>
+          </CommandGroup>
+        </CommandList>
+        <CommandEmpty>No commands</CommandEmpty>
+      </CommandDialog>,
+    );
+
+    await user.type(
+      screen.getByRole("combobox", { name: "Search commands" }),
+      "archive",
+    );
+
+    expect(screen.getByRole("option", { name: "Archive" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Duplicate" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("activates command items", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(
+      <CommandDialog open>
+        <CommandInput aria-label="Search commands" />
+        <CommandList>
+          <CommandGroup heading="Actions">
+            <CommandItem value="archive" label="Archive" onClick={onSelect} />
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>,
+    );
+
+    await user.click(screen.getByRole("option", { name: "Archive" }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders separators through the autocomplete-backed command surface", () => {
+    render(
+      <CommandDialog open>
+        <CommandInput aria-label="Search commands" />
+        <CommandList>
+          <CommandGroup heading="Actions">
+            <CommandItem value="archive" label="Archive" />
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading="Danger">
+            <CommandItem value="delete" label="Delete" />
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>,
+    );
+
+    expect(screen.getByRole("separator")).toHaveAttribute(
+      "data-slot",
+      "command-separator",
+    );
+  });
+});

--- a/packages/ui/src/primitives/command.test.tsx
+++ b/packages/ui/src/primitives/command.test.tsx
@@ -3,12 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  CommandCollection,
   CommandDialog,
   CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
-  CommandCollection,
   CommandList,
   CommandSeparator,
   CommandShortcut,

--- a/packages/ui/src/primitives/command.test.tsx
+++ b/packages/ui/src/primitives/command.test.tsx
@@ -77,6 +77,50 @@ describe("CommandDialog", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("filters object-valued commands through itemToStringValue", async () => {
+    const user = userEvent.setup();
+    const actions = [
+      { id: "archive", title: "Archive page" },
+      { id: "invite", title: "Invite members" },
+    ];
+
+    render(
+      <CommandDialog
+        open
+        items={actions}
+        itemToStringValue={(action) => action.title}
+      >
+        <CommandInput aria-label="Search commands" />
+        <CommandList>
+          <CommandGroup heading="Actions">
+            <CommandCollection>
+              {(action: (typeof actions)[number]) => (
+                <CommandItem
+                  key={action.id}
+                  value={action}
+                  label={action.title}
+                />
+              )}
+            </CommandCollection>
+          </CommandGroup>
+        </CommandList>
+        <CommandEmpty>No commands</CommandEmpty>
+      </CommandDialog>,
+    );
+
+    await user.type(
+      screen.getByRole("combobox", { name: "Search commands" }),
+      "archive",
+    );
+
+    expect(
+      screen.getByRole("option", { name: "Archive page" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Invite members" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("activates command items", async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();

--- a/packages/ui/src/primitives/command.tsx
+++ b/packages/ui/src/primitives/command.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 
 import { cn } from "@notion-kit/cn";
@@ -11,12 +9,12 @@ import {
   AutocompleteEmpty,
   AutocompleteGroup,
   AutocompleteInput,
-  type AutocompleteInputProps,
   AutocompleteItem,
-  type AutocompleteItemProps,
   AutocompleteLabel,
   AutocompleteList,
   AutocompleteSeparator,
+  type AutocompleteInputProps,
+  type AutocompleteItemProps,
   type AutocompleteRootProps,
 } from "./autocomplete";
 import {
@@ -84,7 +82,7 @@ function CommandDialog<ItemValue = string>({
   );
 }
 
-interface CommandInputProps extends AutocompleteInputProps {}
+type CommandInputProps = AutocompleteInputProps;
 
 function CommandInput({ classNames, ...props }: CommandInputProps) {
   return (

--- a/packages/ui/src/primitives/command.tsx
+++ b/packages/ui/src/primitives/command.tsx
@@ -1,10 +1,24 @@
 "use client";
 
 import * as React from "react";
-import { Command as CommandPrimitive, useCommandState } from "cmdk";
 
 import { cn } from "@notion-kit/cn";
 
+import {
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteEmpty,
+  AutocompleteGroup,
+  AutocompleteInput,
+  type AutocompleteInputProps,
+  AutocompleteItem,
+  type AutocompleteItemProps,
+  AutocompleteLabel,
+  AutocompleteList,
+  AutocompleteSeparator,
+  type AutocompleteRootProps,
+} from "./autocomplete";
 import {
   Dialog,
   DialogContent,
@@ -12,39 +26,31 @@ import {
   DialogHeader,
   DialogTitle,
 } from "./dialog";
-import { Input } from "./input";
-import { InputVariants, menuItemVariants, separatorVariants } from "./variants";
+import { MenuItemShortcut } from "./menu";
 
-function Command({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive>) {
-  return (
-    <CommandPrimitive
-      data-slot="command"
-      className={cn(
-        "flex size-full flex-col overflow-hidden rounded-md bg-popover text-primary focus-visible:outline-none",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
-
-interface CommandDialogProps extends React.ComponentProps<typeof Dialog> {
+interface CommandDialogProps<ItemValue = string>
+  extends React.ComponentProps<typeof Dialog>,
+    Pick<
+      AutocompleteRootProps<ItemValue>,
+      "items" | "itemToStringValue" | "filter" | "filteredItems"
+    > {
   className?: string;
-  shouldFilter?: boolean;
   title?: string;
   description?: string;
+  children?: React.ReactNode;
 }
-function CommandDialog({
+
+function CommandDialog<ItemValue = string>({
   className,
-  shouldFilter,
   title = "Command Palette",
   description = "Search for a command to run...",
   children,
+  items,
+  itemToStringValue,
+  filter,
+  filteredItems,
   ...props
-}: CommandDialogProps) {
+}: CommandDialogProps<ItemValue>) {
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
@@ -55,57 +61,52 @@ function CommandDialog({
         className={cn("overflow-hidden p-0 shadow-lg", className)}
         hideClose
       >
-        <Command
-          shouldFilter={shouldFilter}
-          className="bg-modal focus-visible:outline-hidden [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:size-5 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted **:[[cmdk-input]]:h-12"
+        <Autocomplete
+          items={items}
+          itemToStringValue={itemToStringValue}
+          filter={filter}
+          filteredItems={filteredItems}
+          open
+          autoHighlight="always"
+          openOnInputClick
         >
-          {children}
-        </Command>
+          <AutocompleteContent
+            data-slot="command"
+            role="presentation"
+            variant="inline"
+            className="flex size-full flex-col overflow-hidden rounded-md bg-modal text-primary focus-visible:outline-none"
+          >
+            {children}
+          </AutocompleteContent>
+        </Autocomplete>
       </DialogContent>
     </Dialog>
   );
 }
 
-export interface CommandInputProps
-  extends React.ComponentProps<typeof CommandPrimitive.Input> {
-  classNames?: {
-    wrapper?: string;
-  };
-  variant?: InputVariants["variant"];
-  search?: boolean;
-  clear?: boolean;
-  onCancel?: () => void;
-}
-function CommandInput({
-  classNames,
-  onValueChange,
-  ...props
-}: CommandInputProps) {
+interface CommandInputProps extends AutocompleteInputProps {}
+
+function CommandInput({ classNames, ...props }: CommandInputProps) {
   return (
-    <div
-      data-slot="command-input-wrapper"
-      className={cn(
-        "flex min-w-0 flex-auto flex-col px-3 pt-3 pb-2",
-        classNames?.wrapper,
-      )}
-    >
-      <CommandPrimitive.Input data-slot="command-input" asChild>
-        <Input
-          onChange={(e) => onValueChange?.(e.target.value)}
-          onCancel={() => onValueChange?.("")}
-          {...props}
-        />
-      </CommandPrimitive.Input>
-    </div>
+    <AutocompleteInput
+      data-slot="command-input"
+      classNames={{
+        wrapper: cn(
+          "flex min-w-0 flex-auto flex-col px-3 pt-3 pb-2",
+          classNames?.wrapper,
+        ),
+      }}
+      {...props}
+    />
   );
 }
 
 function CommandList({
   className,
   ...props
-}: React.ComponentProps<typeof CommandPrimitive.List>) {
+}: React.ComponentProps<typeof AutocompleteList>) {
   return (
-    <CommandPrimitive.List
+    <AutocompleteList
       data-slot="command-list"
       className={cn(
         "overflow-x-hidden overflow-y-auto focus-visible:outline-none",
@@ -116,12 +117,18 @@ function CommandList({
   );
 }
 
+function CommandCollection({
+  ...props
+}: React.ComponentProps<typeof AutocompleteCollection>) {
+  return <AutocompleteCollection data-slot="command-collection" {...props} />;
+}
+
 function CommandEmpty({
   className,
   ...props
-}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+}: React.ComponentProps<typeof AutocompleteEmpty>) {
   return (
-    <CommandPrimitive.Empty
+    <AutocompleteEmpty
       data-slot="command-empty"
       className={cn("py-2 text-center text-sm select-none", className)}
       {...props}
@@ -129,74 +136,66 @@ function CommandEmpty({
   );
 }
 
-function CommandGroup({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+interface CommandGroupProps
+  extends Omit<React.ComponentProps<typeof AutocompleteGroup>, "heading"> {
+  heading?: React.ReactNode;
+}
+
+function CommandGroup({ heading, children, ...props }: CommandGroupProps) {
   return (
-    <CommandPrimitive.Group
-      data-slot="command-group"
-      className={cn(
-        "overflow-hidden py-1 text-muted **:[[cmdk-group-heading]]:px-3.5 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted",
-        className,
-      )}
-      {...props}
-    />
+    <AutocompleteGroup data-slot="command-group" {...props}>
+      {heading ? <AutocompleteLabel title={heading} /> : null}
+      {children}
+    </AutocompleteGroup>
   );
 }
 
-function CommandSeparator({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
-  return (
-    <CommandPrimitive.Separator
-      data-slot="command-separator"
-      className={cn(separatorVariants({ className }))}
-      {...props}
-    />
-  );
+interface CommandItemProps<ItemValue = string>
+  extends AutocompleteItemProps<ItemValue> {
+  shortcut?: React.ReactNode;
 }
 
-function CommandItem({
-  className,
+function CommandItem<ItemValue = string>({
+  children,
+  shortcut,
   ...props
-}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+}: CommandItemProps<ItemValue>) {
   return (
-    <CommandPrimitive.Item
-      data-slot="command-item"
-      className={cn(
-        menuItemVariants(),
-        "aria-selected:bg-default/5 aria-selected:text-primary",
-        className,
-      )}
-      {...props}
-    />
+    <AutocompleteItem data-slot="command-item" {...props}>
+      {children}
+      {shortcut ? <CommandShortcut>{shortcut}</CommandShortcut> : null}
+    </AutocompleteItem>
   );
 }
 
 function CommandShortcut({
   className,
   ...props
-}: React.HTMLAttributes<HTMLSpanElement>) {
+}: React.ComponentProps<typeof MenuItemShortcut>) {
   return (
-    <span
+    <MenuItemShortcut
       data-slot="command-shortcut"
-      className={cn("ml-auto text-xs tracking-widest text-muted", className)}
+      className={cn("text-xs tracking-widest", className)}
       {...props}
     />
   );
 }
 
+function CommandSeparator({
+  ...props
+}: React.ComponentProps<typeof AutocompleteSeparator>) {
+  return <AutocompleteSeparator data-slot="command-separator" {...props} />;
+}
+
 export {
-  Command,
+  CommandCollection,
   CommandDialog,
-  CommandInput,
-  CommandList,
   CommandEmpty,
   CommandGroup,
+  CommandInput,
   CommandItem,
-  CommandShortcut,
+  CommandList,
   CommandSeparator,
-  useCommandState,
+  CommandShortcut,
 };
+export type { CommandDialogProps, CommandInputProps, CommandItemProps };

--- a/packages/ui/src/primitives/index.ts
+++ b/packages/ui/src/primitives/index.ts
@@ -1,6 +1,7 @@
 /** Variants */
 export * from "./variants";
 /** Shadcn UI */
+export * from "./autocomplete";
 export * from "./avatar";
 export * from "./badge";
 export * from "./button";

--- a/packages/ui/src/primitives/menu.tsx
+++ b/packages/ui/src/primitives/menu.tsx
@@ -136,7 +136,7 @@ function MenuItemSelect({ className, children }: MenuItemActionProps) {
       {children}
       <Icon.Chevron
         side="right"
-        className="ml-1.5 h-full w-3 -rotate-90 fill-icon transition-[rotate] group-data-[state='open']/item:rotate-0"
+        className="ml-1.5 h-full w-3 fill-icon transition-[rotate] group-data-[state='open']/item:rotate-90"
       />
     </MenuItemAction>
   );

--- a/packages/ui/src/selectable/selectable.tsx
+++ b/packages/ui/src/selectable/selectable.tsx
@@ -412,6 +412,7 @@ function Selectable({
     render,
     ref: containerRef,
     props: mergeProps(
+      // eslint-disable-next-line react-hooks/refs
       {
         className: cn("relative touch-none select-none", className),
         style: { touchAction: "none" },

--- a/packages/ui/src/sidebar/core/sidebar.tsx
+++ b/packages/ui/src/sidebar/core/sidebar.tsx
@@ -86,8 +86,8 @@ function Sidebar({
         className={cn(
           "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
           side === "left"
-            ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
-            : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+            ? "left-0 group-data-[collapsible=offcanvas]:-left-(--sidebar-width)"
+            : "right-0 group-data-[collapsible=offcanvas]:-right-(--sidebar-width)",
           // Adjust the padding for floating and inset variants.
           variant === "floating"
             ? "p-2"

--- a/packages/ui/src/sidebar/presets/search-command.tsx
+++ b/packages/ui/src/sidebar/presets/search-command.tsx
@@ -1,11 +1,11 @@
 import { cn } from "@notion-kit/cn";
-import { useFilter } from "@notion-kit/hooks";
 import { Icon } from "@notion-kit/icons";
 import type { Page } from "@notion-kit/schemas";
 import { toDateString } from "@notion-kit/utils";
 
 import { IconBlock } from "@/icon-block";
 import {
+  CommandCollection,
   CommandDialog,
   CommandEmpty,
   CommandGroup,
@@ -13,6 +13,7 @@ import {
   CommandItem,
   CommandList,
   CommandSeparator,
+  MenuItemAction,
 } from "@/primitives";
 
 interface SearchCommandProps {
@@ -35,9 +36,6 @@ export function SearchCommand({
   onSelect,
   onOpenTrash,
 }: SearchCommandProps) {
-  const { search, results, updateSearch } = useFilter(pages, (page, v) =>
-    page.title.toLowerCase().includes(v),
-  );
   /** Search */
   const jumpToTrash = () => {
     onOpenChange?.(false);
@@ -53,14 +51,13 @@ export function SearchCommand({
       className="max-h-[max(50vh,570px)] min-h-[max(50vh,570px)] w-full max-w-[755px] rounded-[12px]"
       open={open}
       onOpenChange={onOpenChange}
-      shouldFilter={false}
+      items={pages}
+      itemToStringValue={(page) => page.title}
     >
       <CommandInput
         search
         clear
         variant="flat"
-        value={search}
-        onValueChange={updateSearch}
         placeholder={`Search in ${workspaceName}...`}
         classNames={{
           wrapper:
@@ -68,65 +65,56 @@ export function SearchCommand({
         }}
         className="size-full min-w-0 px-3 text-lg/[27px]"
       />
-      <CommandList
-        className={cn(
-          "h-full min-h-0 grow transform",
-          !results && "flex flex-col justify-center",
-        )}
-      >
-        {results ? (
-          <CommandGroup className="py-2" heading="Best matches">
-            {results.map((page) => (
+      <CommandList className={cn("h-full min-h-0 grow transform")}>
+        <CommandGroup className="py-2" heading="Best matches">
+          <CommandCollection>
+            {(page: Page) => (
               <CommandItem
                 key={page.id}
-                value={`${page.title}-${page.id}`}
-                title={page.title}
-                onSelect={() => handleSelect(page)}
-                className="group min-h-9"
-              >
-                <div className="mr-2.5 flex items-center justify-center">
+                value={page}
+                label={page.title}
+                icon={
                   <IconBlock
                     icon={page.icon ?? { type: "text", src: page.title }}
                     className="leading-tight"
                   />
-                </div>
-                <div className="mr-1.5 min-w-0 flex-auto truncate">
-                  {page.title}
-                </div>
-                <div className="flex h-3 flex-0 items-center text-xs text-muted">
-                  <span className="truncate group-aria-selected:hidden">
+                }
+                onClick={() => handleSelect(page)}
+                className="group min-h-9"
+              >
+                <MenuItemAction className="flex h-3 flex-0 items-center text-xs text-muted">
+                  <span className="truncate group-data-highlighted:hidden">
                     {toDateString(page.lastEditedAt)}
                   </span>
-                  <span className="hidden size-3 group-aria-selected:block">
+                  <span className="hidden size-3 group-data-highlighted:block">
                     <Icon.Enter className="shrink-0 fill-default/45" />
                   </span>
-                </div>
+                </MenuItemAction>
               </CommandItem>
-            ))}
-          </CommandGroup>
-        ) : (
-          <CommandEmpty className="my-auto flex w-full items-center py-8 leading-tight select-none">
-            <div className="mx-3 min-w-0 flex-auto">
-              <div className="truncate">
-                <div role="alert" className="m-0 font-medium text-secondary">
-                  No results
-                </div>
-              </div>
-              <div className="overflow-hidden text-sm text-ellipsis whitespace-normal">
-                <div className="text-muted">
-                  Some results may be in your deleted pages.
-                  <br />
-                  <button
-                    onClick={jumpToTrash}
-                    className="inline cursor-pointer leading-6 text-blue select-none"
-                  >
-                    Search deleted pages
-                  </button>
-                </div>
+            )}
+          </CommandCollection>
+        </CommandGroup>
+        <CommandEmpty className="my-auto flex w-full items-center py-8 leading-tight select-none">
+          <div className="mx-3 min-w-0 flex-auto">
+            <div className="truncate">
+              <div role="alert" className="m-0 font-medium text-secondary">
+                No results
               </div>
             </div>
-          </CommandEmpty>
-        )}
+            <div className="overflow-hidden text-sm text-ellipsis whitespace-normal">
+              <div className="text-muted">
+                Some results may be in your deleted pages.
+                <br />
+                <button
+                  onClick={jumpToTrash}
+                  className="inline cursor-pointer leading-6 text-blue select-none"
+                >
+                  Search deleted pages
+                </button>
+              </div>
+            </div>
+          </div>
+        </CommandEmpty>
       </CommandList>
       <CommandSeparator />
       <footer className="flex h-7 w-full shrink-0 grow-0 items-center truncate text-sm/tight text-muted select-none">

--- a/packages/ui/src/timezone-menu/index.tsx
+++ b/packages/ui/src/timezone-menu/index.tsx
@@ -39,10 +39,7 @@ export function TimezoneMenu({
 }: TimezoneMenuProps) {
   const defaultTz =
     currentTz ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const timezones = React.useMemo(
-    () => Intl.supportedValuesOf("timeZone"),
-    [],
-  );
+  const timezones = React.useMemo(() => Intl.supportedValuesOf("timeZone"), []);
   const timezoneGroups = React.useMemo(
     () => [
       { label: "Current timezone", items: [defaultTz] },
@@ -69,7 +66,7 @@ export function TimezoneMenu({
         >
           <AutocompleteInput placeholder="Search cities, timezones..." />
           <AutocompleteContent variant="inline">
-            <AutocompleteList className="max-h-100 overflow-y-auto">
+            <AutocompleteList className="max-h-100">
               {(group: (typeof timezoneGroups)[number]) => (
                 <AutocompleteGroup key={group.label} items={group.items}>
                   <AutocompleteLabel title={group.label} />

--- a/packages/ui/src/timezone-menu/index.tsx
+++ b/packages/ui/src/timezone-menu/index.tsx
@@ -4,15 +4,16 @@ import React from "react";
 import { tzOffset } from "@date-fns/tz";
 
 import { cn } from "@notion-kit/cn";
-import { useFilter } from "@notion-kit/hooks";
 
 import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  MenuItem,
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteLabel,
+  AutocompleteList,
   MenuItemCheck,
   Popover,
   PopoverContent,
@@ -38,9 +39,19 @@ export function TimezoneMenu({
 }: TimezoneMenuProps) {
   const defaultTz =
     currentTz ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const { search, results, updateSearch } = useFilter(
-    Intl.supportedValuesOf("timeZone"),
-    (tz, v) => tz.toLowerCase().includes(v),
+  const timezones = React.useMemo(
+    () => Intl.supportedValuesOf("timeZone"),
+    [],
+  );
+  const timezoneGroups = React.useMemo(
+    () => [
+      { label: "Current timezone", items: [defaultTz] },
+      {
+        label: "Select a timezone",
+        items: timezones.filter((tz) => tz !== defaultTz),
+      },
+    ],
+    [defaultTz, timezones],
   );
 
   return (
@@ -49,38 +60,34 @@ export function TimezoneMenu({
         {renderTrigger({ tz: defaultTz, gmt: getGmtStr(defaultTz) })}
       </PopoverTrigger>
       <PopoverContent className={cn("w-[342px]", className)}>
-        <Command shouldFilter={false}>
-          <CommandInput
-            value={search}
-            onValueChange={updateSearch}
-            placeholder={"Search cities, timezones..."}
-          />
-          <CommandList className="max-h-100 overflow-y-auto">
-            <CommandGroup
-              className={cn(
-                "flex flex-col gap-px px-0",
-                "**:[[cmdk-group-heading]]:mt-1.5 **:[[cmdk-group-heading]]:mb-2 **:[[cmdk-group-heading]]:flex **:[[cmdk-group-heading]]:items-center **:[[cmdk-group-heading]]:truncate **:[[cmdk-group-heading]]:px-3.5 **:[[cmdk-group-heading]]:py-0 **:[[cmdk-group-heading]]:leading-tight **:[[cmdk-group-heading]]:text-secondary **:[[cmdk-group-heading]]:select-none",
+        <Autocomplete<string>
+          items={timezoneGroups}
+          itemToStringValue={(tz) => tz}
+          open
+          autoHighlight="always"
+          openOnInputClick
+        >
+          <AutocompleteInput placeholder="Search cities, timezones..." />
+          <AutocompleteContent variant="inline">
+            <AutocompleteList className="max-h-100 overflow-y-auto">
+              {(group: (typeof timezoneGroups)[number]) => (
+                <AutocompleteGroup key={group.label} items={group.items}>
+                  <AutocompleteLabel title={group.label} />
+                  <AutocompleteCollection>
+                    {(tz: string) => (
+                      <TzItem
+                        key={tz}
+                        checked={tz === defaultTz}
+                        tz={tz}
+                        onSelect={onChange}
+                      />
+                    )}
+                  </AutocompleteCollection>
+                </AutocompleteGroup>
               )}
-              heading="Current timezone"
-            >
-              <TzItem checked tz={defaultTz} onSelect={onChange} />
-            </CommandGroup>
-            {results && results.length > 0 && (
-              <CommandGroup
-                className={cn(
-                  "flex flex-col gap-px px-0",
-                  "**:[[cmdk-group-heading]]:mt-1.5 **:[[cmdk-group-heading]]:mb-2 **:[[cmdk-group-heading]]:flex **:[[cmdk-group-heading]]:items-center **:[[cmdk-group-heading]]:truncate **:[[cmdk-group-heading]]:px-3.5 **:[[cmdk-group-heading]]:py-0 **:[[cmdk-group-heading]]:leading-tight **:[[cmdk-group-heading]]:text-secondary **:[[cmdk-group-heading]]:select-none",
-                )}
-                heading="Select a timezone"
-              >
-                {results.map((tz) => {
-                  if (tz === defaultTz) return null;
-                  return <TzItem key={tz} tz={tz} onSelect={onChange} />;
-                })}
-              </CommandGroup>
-            )}
-          </CommandList>
-        </Command>
+            </AutocompleteList>
+          </AutocompleteContent>
+        </Autocomplete>
       </PopoverContent>
     </Popover>
   );
@@ -94,15 +101,15 @@ interface TzItemProps {
 
 function TzItem({ tz, checked, onSelect }: TzItemProps) {
   return (
-    <CommandItem asChild value={tz} onSelect={onSelect}>
-      <MenuItem
-        className="h-11"
-        label={tz.replace("_", " ")}
-        desc={getGmtStr(tz)}
-      >
-        {checked && <MenuItemCheck />}
-      </MenuItem>
-    </CommandItem>
+    <AutocompleteItem
+      className="h-11"
+      value={tz}
+      label={tz.replace("_", " ")}
+      desc={getGmtStr(tz)}
+      onClick={() => onSelect?.(tz)}
+    >
+      {checked && <MenuItemCheck />}
+    </AutocompleteItem>
   );
 }
 

--- a/packages/ui/src/tree/presets/command.tsx
+++ b/packages/ui/src/tree/presets/command.tsx
@@ -111,7 +111,8 @@ function CommandTreeInput({
             }
             break;
           case "ArrowRight": {
-            const firstChild = tree.entity.nodes.get(highlightedId)?.children[0];
+            const firstChild =
+              tree.entity.nodes.get(highlightedId)?.children[0];
             if (!firstChild) return;
             if (!tree.state.expanded.has(highlightedId)) {
               tree.expand(highlightedId);

--- a/packages/ui/src/tree/presets/command.tsx
+++ b/packages/ui/src/tree/presets/command.tsx
@@ -4,14 +4,14 @@ import { cn } from "@notion-kit/cn";
 import { Icon } from "@notion-kit/icons";
 
 import {
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteContent,
+  AutocompleteGroup,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteList,
   Button,
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  MenuItem,
-  useCommandState,
 } from "@/primitives";
 
 import { Tree as TreePrimitive, type TreeInstance } from "../core";
@@ -23,74 +23,99 @@ interface CommandTreeProps<T extends TreeItemData> {
 
 function CommandTree<T extends TreeItemData>({ tree }: CommandTreeProps<T>) {
   const [input, setInput] = useState("");
+  const [highlightedId, setHighlightedId] = useState<string | undefined>();
   const mode = input === "" ? "browse" : "search";
+  const nodeIds = Array.from(tree.entity.nodes.keys());
 
   return (
-    <Command shouldFilter>
-      <CommandTreeInput tree={tree} value={input} onValueChange={setInput} />
-      <CommandGroup>
+    <Autocomplete
+      items={nodeIds}
+      itemToStringValue={(id) => tree.entity.nodes.get(id)?.title ?? id}
+      mode={mode === "browse" ? "none" : "list"}
+      value={input}
+      onValueChange={setInput}
+      onItemHighlighted={(id) => setHighlightedId(id)}
+      open
+      autoHighlight="always"
+      openOnInputClick
+    >
+      <CommandTreeInput
+        tree={tree}
+        value={input}
+        highlightedId={highlightedId}
+      />
+      <AutocompleteContent role="presentation" variant="inline">
         {mode === "browse" ? (
-          <CommandList>
-            <TreePrimitive tree={tree}>
-              <CommandTreeList nodeIds={tree.entity.rootIds} />
-            </TreePrimitive>
-          </CommandList>
+          <AutocompleteList>
+            <AutocompleteGroup>
+              <TreePrimitive tree={tree}>
+                <CommandTreeList nodeIds={tree.entity.rootIds} />
+              </TreePrimitive>
+            </AutocompleteGroup>
+          </AutocompleteList>
         ) : (
-          <CommandList>
-            {Array.from(tree.entity.nodes.entries()).map(([id, node]) => {
-              return (
-                <CommandItem key={id} value={node.title} asChild>
-                  <MenuItem
-                    data-slot="tree-item"
-                    variant="sidebar"
-                    className="focus:shadow-notion"
-                    icon={
-                      <Button variant="hint" className="relative size-5">
-                        {node.icon}
-                      </Button>
-                    }
-                    label={node.title}
-                  />
-                </CommandItem>
-              );
-            })}
-          </CommandList>
+          <AutocompleteList>
+            <AutocompleteGroup items={nodeIds}>
+              <AutocompleteCollection>
+                {(id: string) => {
+                  const node = tree.entity.nodes.get(id);
+                  if (!node) return null;
+
+                  return (
+                    <AutocompleteItem
+                      key={id}
+                      value={id}
+                      data-slot="tree-item"
+                      variant="sidebar"
+                      className="focus:shadow-notion"
+                      icon={
+                        <Button variant="hint" className="relative size-5">
+                          {node.icon}
+                        </Button>
+                      }
+                      label={node.title}
+                    />
+                  );
+                }}
+              </AutocompleteCollection>
+            </AutocompleteGroup>
+          </AutocompleteList>
         )}
-      </CommandGroup>
-    </Command>
+      </AutocompleteContent>
+    </Autocomplete>
   );
 }
 
 interface CommandTreeInputProps {
   tree: TreeInstance<TreeItemData>;
   value: string;
-  onValueChange: (value: string) => void;
+  highlightedId?: string;
 }
 
 function CommandTreeInput({
   tree,
   value,
-  onValueChange,
+  highlightedId,
 }: CommandTreeInputProps) {
-  const id = useCommandState((state) => state.selectedItemId);
-
   return (
-    <CommandInput
+    <AutocompleteInput
       placeholder="Type to search..."
-      value={value}
-      onValueChange={onValueChange}
       onKeyDown={(e) => {
         // only handle in browse mode
-        if (value !== "" || !id) return;
+        if (value !== "" || !highlightedId) return;
 
         switch (e.key) {
           case "ArrowLeft":
-            if (tree.state.expanded.has(id)) tree.expand(id);
+            if (tree.state.expanded.has(highlightedId)) {
+              tree.expand(highlightedId);
+            }
             break;
           case "ArrowRight": {
-            const firstChild = tree.entity.nodes.get(id)?.children[0];
+            const firstChild = tree.entity.nodes.get(highlightedId)?.children[0];
             if (!firstChild) return;
-            if (!tree.state.expanded.has(id)) tree.expand(id);
+            if (!tree.state.expanded.has(highlightedId)) {
+              tree.expand(highlightedId);
+            }
             break;
           }
         }
@@ -109,42 +134,41 @@ function CommandTreeList<T extends TreeItemData>({
       nodeIds={nodeIds}
       renderItem={({ node, tree, state }) => {
         return (
-          <CommandItem key={node.id} value={node.title} asChild>
-            <MenuItem
-              id={node.id}
-              data-slot="tree-item"
-              variant="sidebar"
-              className="focus:bg-default/5"
-              icon={
-                <div className="group/icon">
-                  <TreePrimitive.ExpandIndicator
-                    onToggle={() => tree.expand(node.id)}
-                    render={
-                      <Button
-                        variant="hint"
-                        className={cn(
-                          "relative size-5",
-                          node.icon && "hidden group-hover/icon:flex",
-                        )}
-                        aria-label={state.expanded ? "collapse" : "expand"}
-                      >
-                        <Icon.Chevron
-                          side={state.expanded ? "down" : "right"}
-                          className="size-3 rotate-0 transition-[rotate]"
-                        />
-                      </Button>
-                    }
-                  />
-                  {node.icon && (
-                    <div className="flex size-5 items-center justify-center group-hover/icon:hidden">
-                      {node.icon}
-                    </div>
-                  )}
-                </div>
-              }
-              label={node.title}
-            />
-          </CommandItem>
+          <AutocompleteItem
+            key={node.id}
+            value={node.id}
+            data-slot="tree-item"
+            variant="sidebar"
+            className="focus:bg-default/5"
+            icon={
+              <div className="group/icon">
+                <TreePrimitive.ExpandIndicator
+                  onToggle={() => tree.expand(node.id)}
+                  render={
+                    <Button
+                      variant="hint"
+                      className={cn(
+                        "relative size-5",
+                        node.icon && "hidden group-hover/icon:flex",
+                      )}
+                      aria-label={state.expanded ? "collapse" : "expand"}
+                    >
+                      <Icon.Chevron
+                        side={state.expanded ? "down" : "right"}
+                        className="size-3 rotate-0 transition-[rotate]"
+                      />
+                    </Button>
+                  }
+                />
+                {node.icon && (
+                  <div className="flex size-5 items-center justify-center group-hover/icon:hidden">
+                    {node.icon}
+                  </div>
+                )}
+              </div>
+            }
+            label={node.title}
+          />
         );
       }}
     />

--- a/packages/ui/tsdown.config.ts
+++ b/packages/ui/tsdown.config.ts
@@ -13,7 +13,6 @@ const THIRD_PARTY = [
   /^@radix-ui\//,
   /^@tanstack\//,
   /^@uidotdev\//,
-  "cmdk",
   "date-fns",
   "i18next",
   "jotai",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1849,9 +1849,6 @@ importers:
       '@uidotdev/usehooks':
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      cmdk:
-        specifier: ^1.1.1
-        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       date-fns:
         specifier: catalog:fns
         version: 4.1.0
@@ -7152,12 +7149,6 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  cmdk@1.1.1:
-    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
-    peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -16753,18 +16744,6 @@ snapshots:
   clone@1.0.4: {}
 
   clsx@2.1.1: {}
-
-  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
 
   collapse-white-space@2.1.0: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new `Autocomplete` primitive and rebuilds `Command` as a dialog-only API on top of it, replacing `cmdk`. Migrates search-based menus and command palettes to `Popover + Autocomplete` for a consistent Notion-style UX.

- **New Features**
  - Added `@notion-kit/ui` `Autocomplete` with `input`, `content`, `list`, `group`, `label`, `separator`, `empty`, and `item` slots; supports grouped `items` and `AutocompleteCollection`.
  - Rewrote `Command` to dialog-only on `Autocomplete`; introduced `CommandCollection`, `CommandEmpty/Group/Item/Separator/Shortcut`.
  - Added docs pages, registry demos, Storybook stories, and unit tests for `Autocomplete` and `CommandDialog`; updated docs and references to the new APIs.
  - Removed `cmdk` from `packages/ui`, repo config, and lockfile.

- **Migration**
  - In popovers, replace `Command` with `Autocomplete` and keep existing `Popover` wrappers.
  - Import `Autocomplete*` for popover menus and `CommandDialog*` for command palettes.
  - Pass `items` to the root and render rows via `AutocompleteCollection`/`CommandCollection`; use `icon` and `label` on menu items.
  - Migrated code-block actions and language/theme menus, table-view menus (prop, row action, select group, sort, types), timezone menu, globe transit-entity search, tree command, and sidebar search to `Autocomplete`.

<sup>Written for commit 7215c32fdad130078679b0cf401f014d853d2511. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/steeeee0223/notion-kit/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

