### PR TITLE
feat: migrate dialog, sheet, drawer. remove forceMount prop

### DIFF
--- a/apps/storybook/src/stories/ui/dialog.stories.tsx
+++ b/apps/storybook/src/stories/ui/dialog.stories.tsx
@@ -18,9 +18,7 @@ export const Default: Story = {
     const [open, setOpen] = useState(false);
     return (
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogTrigger asChild>
-          <Button size="md">Open</Button>
-        </DialogTrigger>
+        <DialogTrigger render={<Button size="md">Open</Button>} />
         <AlertModal
           title="This action cannot be undone. This will permanently delete your account and remove your data from our servers."
           primary="Continue"

--- a/examples/notion-clone/src/components/settings-modal.tsx
+++ b/examples/notion-clone/src/components/settings-modal.tsx
@@ -24,16 +24,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         noTitle
-        className="flex h-[calc(100vh-100px)] max-h-[720px] w-[calc(100vw-100px)] max-w-[1150px] rounded-md border-none p-0 shadow-sm"
-        onClick={(e) => e.stopPropagation()}
-        /**
-         * tmporary fix
-         * @see https://github.com/radix-ui/primitives/issues/1241
-         */
-        onCloseAutoFocus={(e) => {
-          e.preventDefault();
-          document.body.style.pointerEvents = "";
-        }}
+        className="flex h-[calc(100vh-100px)] max-h-180 w-[calc(100vw-100px)] max-w-[1150px] rounded-md border-none p-0 shadow-sm"
       >
         <SettingsProvider adapters={adapters}>
           <SettingsPanel>

--- a/issues.md
+++ b/issues.md
@@ -2,15 +2,9 @@
 
 issues recording for current task
 
-1. combobox-multiple-inline.tsx -> current filtering behavior is NOT same as combobox-multiple-floating.tsx
-2. add-members.tsx -> state needs to be refactored to fit better with `base-ui`'s usage (or see combobox-multiple-floating.tsx), also avoid using `useFilter`
-3. menu issues!
-   1. content or portal z-index wrong! (e.g. in sidebar-presets, table-view)
-      - root cause: table-view was mixing Popover, visual-only MenuItem rows, DropdownMenu, Autocomplete, and Select portals in the same menu flow. Nested/competing floating roots each applied their own portal/focus/dismiss semantics, so child content could render outside the active stack or be treated as outside interaction.
-4. [x] select-preset: remove this!
-   1. [x] first migration
-   2. [x] to fix: settings-panel modals
-5. [ ] Some select in dialog may occur z-index issue, since dialog is NOT yet migrated to base-ui
+1. [ ] combobox-multiple-inline.tsx -> current filtering behavior is NOT same as combobox-multiple-floating.tsx
+2. [ ] migrate tooltip!
+3. [ ] update `contentVariants` to new design after migration
 
 ## Table view menus
 

--- a/packages/hooks/src/use-input-field.ts
+++ b/packages/hooks/src/use-input-field.ts
@@ -65,6 +65,7 @@ export function useInputField({
         onUpdate?.(value);
       },
       onKeyDown: (e) => {
+        e.stopPropagation();
         if (e.key !== "Enter" || value === initialValue) return;
         if (!error) onUpdate?.(value);
         onKeyDownUpdate?.();

--- a/packages/map/src/map-marker.tsx
+++ b/packages/map/src/map-marker.tsx
@@ -326,7 +326,7 @@ export function MapMarkerTooltip({
       data-slot="map-marker-tooltip"
       className={cn(
         contentVariants({ variant: "tooltip", openAnimation: true }),
-        tooltipVariants({ size: "sm" }),
+        tooltipVariants(),
         className,
       )}
     >

--- a/packages/registry/src/tooltip-demo/tooltip-demo.tsx
+++ b/packages/registry/src/tooltip-demo/tooltip-demo.tsx
@@ -13,9 +13,7 @@ export default function Demo() {
         <TooltipTrigger asChild>
           <Button size="md">Hover</Button>
         </TooltipTrigger>
-        <TooltipContent>
-          <p>Add to library</p>
-        </TooltipContent>
+        <TooltipContent>Add to library </TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );

--- a/packages/settings-panel/src/presets/account/devices-section.tsx
+++ b/packages/settings-panel/src/presets/account/devices-section.tsx
@@ -1,12 +1,11 @@
-"use client";
-
 import { useTranslation } from "@notion-kit/i18n";
 import { Button, Dialog, DialogTrigger } from "@notion-kit/ui/primitives";
 
-import { SettingsRule, SettingsSection } from "../../core";
-import { useAccount } from "../hooks";
-import { LogoutConfirm } from "../modals";
-import { SessionsTable } from "../tables";
+import { SettingsRule, SettingsSection } from "@/core";
+import { useAccount } from "@/presets/hooks";
+import { LogoutConfirm } from "@/presets/modals";
+import { SessionsTable } from "@/presets/tables";
+
 import { useSessions } from "./use-sessions";
 
 export function DevicesSection() {
@@ -21,11 +20,13 @@ export function DevicesSection() {
     <SettingsSection title={trans.title}>
       <SettingsRule {...trans.logout}>
         <Dialog>
-          <DialogTrigger asChild>
-            <Button size="xs" className="text-secondary">
-              {trans.logout.button}
-            </Button>
-          </DialogTrigger>
+          <DialogTrigger
+            render={
+              <Button size="xs" className="text-secondary">
+                {trans.logout.button}
+              </Button>
+            }
+          />
           <LogoutConfirm
             title="Log out of all devices?"
             description="You will be logged out of all other active sessions on other devices except this one."

--- a/packages/settings-panel/src/presets/account/security-section.tsx
+++ b/packages/settings-panel/src/presets/account/security-section.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useState } from "react";
 
 import { useTranslation } from "@notion-kit/i18n";
@@ -10,9 +8,9 @@ import {
   Switch,
 } from "@notion-kit/ui/primitives";
 
-import { SettingsRule, SettingsSection } from "../../core";
-import { useAccount, useAccountActions } from "../hooks";
-import { EmailSettings, PasskeysModal, PasswordForm } from "../modals";
+import { SettingsRule, SettingsSection } from "@/core";
+import { useAccount, useAccountActions } from "@/presets/hooks";
+import { EmailSettings, PasskeysModal, PasswordForm } from "@/presets/modals";
 
 export function SecuritySection() {
   const [passwordOpen, setPasswordOpen] = useState(false);
@@ -29,9 +27,9 @@ export function SecuritySection() {
     <SettingsSection title={trans.title}>
       <SettingsRule title={trans.email.title} description={account.email}>
         <Dialog>
-          <DialogTrigger asChild>
-            <Button size="sm">{trans.email.button}</Button>
-          </DialogTrigger>
+          <DialogTrigger
+            render={<Button size="sm">{trans.email.button}</Button>}
+          />
           <EmailSettings
             email={account.email}
             onSendVerification={() => sendEmailVerification(account.email)}
@@ -70,9 +68,9 @@ export function SecuritySection() {
       </SettingsRule>
       <SettingsRule {...trans.passkeys}>
         <Dialog>
-          <DialogTrigger asChild>
-            <Button size="sm">{trans.passkeys.button}</Button>
-          </DialogTrigger>
+          <DialogTrigger
+            render={<Button size="sm">{trans.passkeys.button}</Button>}
+          />
           <PasskeysModal />
         </Dialog>
       </SettingsRule>

--- a/packages/settings-panel/src/presets/account/support-section.tsx
+++ b/packages/settings-panel/src/presets/account/support-section.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useState } from "react";
 
 import { useTranslation } from "@notion-kit/i18n";
@@ -11,9 +9,9 @@ import {
   Switch,
 } from "@notion-kit/ui/primitives";
 
-import { SettingsRule, SettingsSection } from "../../core";
-import { useAccount, useAccountActions } from "../hooks";
-import { DeleteAccount } from "../modals";
+import { SettingsRule, SettingsSection } from "@/core";
+import { useAccount, useAccountActions } from "@/presets/hooks";
+import { DeleteAccount } from "@/presets/modals";
 
 export function SupportSection() {
   /** i18n */
@@ -34,11 +32,13 @@ export function SupportSection() {
         className="**:data-[slot=settings-rule-title]:text-red"
       >
         <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-          <DialogTrigger asChild>
-            <Button variant="hint" className="size-5">
-              <Icon.Chevron side="right" className="size-3 fill-default/35" />
-            </Button>
-          </DialogTrigger>
+          <DialogTrigger
+            render={
+              <Button variant="hint" className="size-5">
+                <Icon.Chevron side="right" className="size-3 fill-default/35" />
+              </Button>
+            }
+          />
           <DeleteAccount
             email={account.email}
             onSubmit={async (email) => {

--- a/packages/settings-panel/src/presets/billing/payment-details-section.tsx
+++ b/packages/settings-panel/src/presets/billing/payment-details-section.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useState } from "react";
 
 import { useTranslation } from "@notion-kit/i18n";
@@ -42,11 +40,13 @@ export function PaymentDetailsSection() {
           open={openChangePaymentMethod}
           onOpenChange={setOpenChangePaymentMethod}
         >
-          <DialogTrigger asChild>
-            <Button size="sm" className="w-36">
-              {trans["payment-method"].button}
-            </Button>
-          </DialogTrigger>
+          <DialogTrigger
+            render={
+              <Button size="sm" className="w-36">
+                {trans["payment-method"].button}
+              </Button>
+            }
+          />
           <ChangePaymentMethod
             stripePromise={stripePromise}
             onConfirm={async () => {
@@ -62,11 +62,13 @@ export function PaymentDetailsSection() {
         description={billing.billedTo ?? "-"}
       >
         <Dialog open={openChangeBilledTo} onOpenChange={setOpenChangeBilledTo}>
-          <DialogTrigger asChild>
-            <Button size="sm" className="w-36">
-              {trans["billed-to"].button}
-            </Button>
-          </DialogTrigger>
+          <DialogTrigger
+            render={
+              <Button size="sm" className="w-36">
+                {trans["billed-to"].button}
+              </Button>
+            }
+          />
           <ChangeBillingAddress
             stripePromise={stripePromise}
             onConfirm={async (addr) => {
@@ -85,11 +87,13 @@ export function PaymentDetailsSection() {
           open={openChangeBillingEmail}
           onOpenChange={setOpenChangeBillingEmail}
         >
-          <DialogTrigger asChild>
-            <Button size="sm" className="w-36">
-              {trans["billing-email"].button}
-            </Button>
-          </DialogTrigger>
+          <DialogTrigger
+            render={
+              <Button size="sm" className="w-36">
+                {trans["billing-email"].button}
+              </Button>
+            }
+          />
           <ChangeBillingEmail
             email={billing.billingEmail}
             onConfirm={async (email) => {

--- a/packages/settings-panel/src/presets/billing/plan-section.tsx
+++ b/packages/settings-panel/src/presets/billing/plan-section.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useState } from "react";
 
 import { useTranslation } from "@notion-kit/i18n";
@@ -27,11 +25,13 @@ export function PlanSection() {
     <SettingsSection title={t("title")}>
       <SettingsRule title={trans.title} description={workspace.plan}>
         <Dialog open={openChangePlan} onOpenChange={setOpenChangePlan}>
-          <DialogTrigger asChild>
-            <Button size="sm" className="w-36">
-              {trans.button}
-            </Button>
-          </DialogTrigger>
+          <DialogTrigger
+            render={
+              <Button size="sm" className="w-36">
+                {trans.button}
+              </Button>
+            }
+          />
           <ChangePlan
             currentPlan={workspace.plan}
             onConfirm={async (plan) => {

--- a/packages/settings-panel/src/presets/general/danger-section.tsx
+++ b/packages/settings-panel/src/presets/general/danger-section.tsx
@@ -31,11 +31,13 @@ export function DangerSection() {
             href="https://www.notion.com/help/create-delete-and-switch-workspaces#delete-workspace"
           >
             <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-              <DialogTrigger asChild>
-                <Button variant="red" size="sm">
-                  {trans.delete}
-                </Button>
-              </DialogTrigger>
+              <DialogTrigger
+                render={
+                  <Button variant="red" size="sm">
+                    {trans.delete}
+                  </Button>
+                }
+              />
               <DeleteWorkspace
                 name={workspace.name}
                 onSubmit={async () => {
@@ -49,11 +51,13 @@ export function DangerSection() {
       ) : (
         <Dialog>
           <Content>
-            <DialogTrigger asChild>
-              <Button variant="red" size="sm">
-                {trans.leave}
-              </Button>
-            </DialogTrigger>
+            <DialogTrigger
+              render={
+                <Button variant="red" size="sm">
+                  {trans.leave}
+                </Button>
+              }
+            />
           </Content>
           <AlertModal
             {...modalsTrans.leave}

--- a/packages/settings-panel/src/presets/modals/add-members/add-members.tsx
+++ b/packages/settings-panel/src/presets/modals/add-members/add-members.tsx
@@ -119,17 +119,19 @@ export function AddMembers({
                 {t("invite")}
                 {form.formState.isSubmitting && <Spinner />}
               </Button>
-              <DialogClose asChild>
-                <Button
-                  type="button"
-                  variant="hint"
-                  size="sm"
-                  className="w-full"
-                  disabled={form.formState.isSubmitting}
-                >
-                  {t("cancel")}
-                </Button>
-              </DialogClose>
+              <DialogClose
+                render={
+                  <Button
+                    type="button"
+                    variant="hint"
+                    size="sm"
+                    className="w-full"
+                    disabled={form.formState.isSubmitting}
+                  >
+                    {t("cancel")}
+                  </Button>
+                }
+              />
             </DialogFooter>
           </form>
         </Form>

--- a/packages/settings-panel/src/presets/modals/add-team-members/add-team-members.tsx
+++ b/packages/settings-panel/src/presets/modals/add-team-members/add-team-members.tsx
@@ -51,7 +51,10 @@ export function AddTeamMembers({
       hideClose
       className="max-h-1/2 min-h-50 w-125"
       aria-describedby=""
-      onCloseAutoFocus={() => form.reset()}
+      finalFocus={() => {
+        form.reset();
+        return true;
+      }}
     >
       <DialogHeader className="items-start text-left">
         <DialogTitle typography="h2" className="flex items-center text-start">

--- a/packages/settings-panel/src/presets/modals/change-billing-address.tsx
+++ b/packages/settings-panel/src/presets/modals/change-billing-address.tsx
@@ -156,16 +156,18 @@ function AddressFormStripe({
         </div>
       </div>
       <div className="flex items-center justify-end gap-2">
-        <DialogClose asChild>
-          <Button
-            type="button"
-            variant="hint"
-            size="sm"
-            className="text-secondary"
-          >
-            {t("cancel")}
-          </Button>
-        </DialogClose>
+        <DialogClose
+          render={
+            <Button
+              type="button"
+              variant="hint"
+              size="sm"
+              className="text-secondary"
+            >
+              {t("cancel")}
+            </Button>
+          }
+        />
         <Button
           type="button"
           variant="blue"
@@ -290,16 +292,18 @@ function ChangeBillingAddressNative({
             )}
           />
           <div className="flex items-center justify-end gap-2">
-            <DialogClose asChild>
-              <Button
-                type="button"
-                variant="hint"
-                size="sm"
-                className="text-secondary"
-              >
-                {t("cancel")}
-              </Button>
-            </DialogClose>
+            <DialogClose
+              render={
+                <Button
+                  type="button"
+                  variant="hint"
+                  size="sm"
+                  className="text-secondary"
+                >
+                  {t("cancel")}
+                </Button>
+              }
+            />
             <Button
               type="submit"
               variant="blue"

--- a/packages/settings-panel/src/presets/modals/change-billing-email.tsx
+++ b/packages/settings-panel/src/presets/modals/change-billing-email.tsx
@@ -61,16 +61,18 @@ export function ChangeBillingEmail({
             )}
           />
           <div className="flex items-center justify-end gap-2">
-            <DialogClose asChild>
-              <Button
-                type="button"
-                variant="hint"
-                size="sm"
-                className="text-secondary"
-              >
-                {t("cancel")}
-              </Button>
-            </DialogClose>
+            <DialogClose
+              render={
+                <Button
+                  type="button"
+                  variant="hint"
+                  size="sm"
+                  className="text-secondary"
+                >
+                  {t("cancel")}
+                </Button>
+              }
+            />
             <Button
               type="submit"
               variant="blue"

--- a/packages/settings-panel/src/presets/modals/change-payment-method.tsx
+++ b/packages/settings-panel/src/presets/modals/change-payment-method.tsx
@@ -73,16 +73,18 @@ function PaymentMethodForm({ onConfirm }: PaymentMethodFormProps) {
         />
       </div>
       <div className="flex items-center justify-end gap-2">
-        <DialogClose asChild>
-          <Button
-            type="button"
-            variant="hint"
-            size="sm"
-            className="text-secondary"
-          >
-            {t("cancel")}
-          </Button>
-        </DialogClose>
+        <DialogClose
+          render={
+            <Button
+              type="button"
+              variant="hint"
+              size="sm"
+              className="text-secondary"
+            >
+              {t("cancel")}
+            </Button>
+          }
+        />
         <Button
           type="button"
           variant="blue"

--- a/packages/settings-panel/src/presets/modals/change-plan.tsx
+++ b/packages/settings-panel/src/presets/modals/change-plan.tsx
@@ -110,11 +110,13 @@ export function ChangePlan({ currentPlan, onConfirm }: ChangePlanProps) {
           {t("continue")}
           {isPending && <Spinner />}
         </Button>
-        <DialogClose asChild>
-          <Button variant="hint" size="sm" className="text-secondary">
-            {t("cancel")}
-          </Button>
-        </DialogClose>
+        <DialogClose
+          render={
+            <Button variant="hint" size="sm" className="text-secondary">
+              {t("cancel")}
+            </Button>
+          }
+        />
       </div>
     </DialogContent>
   );

--- a/packages/settings-panel/src/presets/modals/create-teamspace/permission-select.tsx
+++ b/packages/settings-panel/src/presets/modals/create-teamspace/permission-select.tsx
@@ -37,9 +37,19 @@ export function PermissionSelect({
       }}
       disabled={disabled}
     >
-      <SelectTrigger className="h-fit border border-border pl-0">
+      <SelectTrigger className="h-fit justify-between border border-border pl-0 text-left">
         <SelectValue>
-          {(option) => <TeamspacePermission {...option} />}
+          {(value: Permission) => {
+            const permission = permissionOptions.find(
+              (option) => option.value === value,
+            );
+            return (
+              <TeamspacePermission
+                className="hover:bg-transparent data-highlighted:bg-transparent"
+                {...permission}
+              />
+            );
+          }}
         </SelectValue>
       </SelectTrigger>
       <SelectContent>

--- a/packages/settings-panel/src/presets/modals/delete-account.tsx
+++ b/packages/settings-panel/src/presets/modals/delete-account.tsx
@@ -50,7 +50,7 @@ export function DeleteAccount({ email, onSubmit }: DeleteAccountProps) {
   });
 
   return (
-    <DialogContent className="w-[420px] p-5">
+    <DialogContent className="w-105">
       <DialogHeader>
         <DialogIcon>
           <Icon.ExclamationMarkCircled className="size-9 fill-red" />
@@ -92,17 +92,19 @@ export function DeleteAccount({ email, onSubmit }: DeleteAccountProps) {
             >
               {t("delete")}
             </Button>
-            <DialogClose asChild>
-              <Button
-                type="button"
-                variant="hint"
-                size="sm"
-                className="h-7 w-fit"
-                disabled={form.formState.isSubmitting}
-              >
-                {t("cancel")}
-              </Button>
-            </DialogClose>
+            <DialogClose
+              render={
+                <Button
+                  type="button"
+                  variant="hint"
+                  size="sm"
+                  className="h-7 w-fit"
+                  disabled={form.formState.isSubmitting}
+                >
+                  {t("cancel")}
+                </Button>
+              }
+            />
           </DialogFooter>
         </form>
       </Form>

--- a/packages/settings-panel/src/presets/modals/delete-guest.tsx
+++ b/packages/settings-panel/src/presets/modals/delete-guest.tsx
@@ -28,7 +28,7 @@ export function DeleteGuest({ name, onDelete }: DeleteGuestProps) {
   const onRemove = () => startTransition(() => onDelete?.());
 
   return (
-    <DialogContent className="w-[300px] p-5">
+    <DialogContent className="w-75">
       <DialogHeader>
         <DialogIcon>
           <Icon.UserX className="size-9 fill-default/45" />
@@ -48,11 +48,13 @@ export function DeleteGuest({ name, onDelete }: DeleteGuestProps) {
           {t("remove")}
           {loading && <Spinner />}
         </Button>
-        <DialogClose asChild>
-          <Button variant="hint" size="sm" className="h-7 w-fit">
-            {t("cancel")}
-          </Button>
-        </DialogClose>
+        <DialogClose
+          render={
+            <Button variant="hint" size="sm" className="h-7 w-fit">
+              {t("cancel")}
+            </Button>
+          }
+        />
       </DialogFooter>
     </DialogContent>
   );

--- a/packages/settings-panel/src/presets/modals/delete-member.tsx
+++ b/packages/settings-panel/src/presets/modals/delete-member.tsx
@@ -58,11 +58,13 @@ export function DeleteMember({ onDelete }: DeleteMemberProps) {
           {t("continue")}
           {loading && <Spinner />}
         </Button>
-        <DialogClose asChild>
-          <Button variant="hint" size="sm" className="h-7 w-fit">
-            {t("cancel")}
-          </Button>
-        </DialogClose>
+        <DialogClose
+          render={
+            <Button variant="hint" size="sm" className="h-7 w-fit">
+              {t("cancel")}
+            </Button>
+          }
+        />
       </DialogFooter>
     </DialogContent>
   );

--- a/packages/settings-panel/src/presets/modals/delete-workspace.tsx
+++ b/packages/settings-panel/src/presets/modals/delete-workspace.tsx
@@ -50,7 +50,7 @@ export function DeleteWorkspace({ name, onSubmit }: DeleteWorkspaceProps) {
   };
 
   return (
-    <DialogContent className="w-[420px] p-5">
+    <DialogContent className="w-105 p-5">
       <DialogHeader>
         <DialogIcon>
           <Icon.ExclamationMarkCircled className="size-9 fill-red" />
@@ -86,16 +86,18 @@ export function DeleteWorkspace({ name, onSubmit }: DeleteWorkspaceProps) {
             >
               {t("delete")}
             </Button>
-            <DialogClose asChild>
-              <Button
-                variant="hint"
-                size="sm"
-                className="h-7 w-fit"
-                disabled={form.formState.isSubmitting}
-              >
-                {t("cancel")}
-              </Button>
-            </DialogClose>
+            <DialogClose
+              render={
+                <Button
+                  variant="hint"
+                  size="sm"
+                  className="h-7 w-fit"
+                  disabled={form.formState.isSubmitting}
+                >
+                  {t("cancel")}
+                </Button>
+              }
+            />
           </DialogFooter>
         </form>
       </Form>

--- a/packages/settings-panel/src/presets/modals/emoji-form.tsx
+++ b/packages/settings-panel/src/presets/modals/emoji-form.tsx
@@ -59,10 +59,11 @@ export function EmojiForm({ emoji, onSave }: EmojiFormProps) {
   return (
     <DialogContent
       className="w-70"
-      onCloseAutoFocus={() => {
+      finalFocus={() => {
         form.reset();
         if (preview) URL.revokeObjectURL(preview);
         setPreview(null);
+        return true;
       }}
     >
       <Form {...form}>
@@ -162,16 +163,18 @@ export function EmojiForm({ emoji, onSave }: EmojiFormProps) {
             )}
           />
           <div className="flex items-center justify-between gap-2">
-            <DialogClose asChild>
-              <Button
-                type="button"
-                variant="hint"
-                size="sm"
-                className="font-normal"
-              >
-                {t("cancel")}
-              </Button>
-            </DialogClose>
+            <DialogClose
+              render={
+                <Button
+                  type="button"
+                  variant="hint"
+                  size="sm"
+                  className="font-normal"
+                >
+                  {t("cancel")}
+                </Button>
+              }
+            />
             <Button
               type="submit"
               variant="blue"

--- a/packages/settings-panel/src/presets/modals/leave-teamspace.tsx
+++ b/packages/settings-panel/src/presets/modals/leave-teamspace.tsx
@@ -29,7 +29,7 @@ export function LeaveTeamspace({ name, onLeave }: LeaveTeamspaceProps) {
   const leave = () => startTransition(() => onLeave?.());
 
   return (
-    <DialogContent className="w-[300px] p-5">
+    <DialogContent className="w-75">
       <DialogHeader>
         <DialogTitle typography="h2">{t("title", { name })}</DialogTitle>
       </DialogHeader>
@@ -47,11 +47,13 @@ export function LeaveTeamspace({ name, onLeave }: LeaveTeamspaceProps) {
           {t("remove")}
           {isLeaving && <Spinner />}
         </Button>
-        <DialogClose asChild>
-          <Button variant="hint" size="sm" className="h-7 w-fit">
-            {t("cancel")}
-          </Button>
-        </DialogClose>
+        <DialogClose
+          render={
+            <Button variant="hint" size="sm" className="h-7 w-fit">
+              {t("cancel")}
+            </Button>
+          }
+        />
       </DialogFooter>
     </DialogContent>
   );

--- a/packages/settings-panel/src/presets/modals/logout-confirm.tsx
+++ b/packages/settings-panel/src/presets/modals/logout-confirm.tsx
@@ -33,15 +33,13 @@ export function LogoutConfirm({
   const logout = () => startTransition(async () => await onConfirm?.());
 
   return (
-    <DialogContent className="w-[324px] p-5" hideClose>
+    <DialogContent className="w-81" hideClose>
       <DialogHeader>
         <DialogIcon>
           <Icon.PersonBadgeExclamationMark className="size-8 fill-muted" />
         </DialogIcon>
         <DialogTitle typography="h2">{title}</DialogTitle>
-        <DialogDescription typography="h2" className="text-muted">
-          {description}
-        </DialogDescription>
+        <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
       <DialogFooter>
         <Button
@@ -55,16 +53,18 @@ export function LogoutConfirm({
           {isPending && <Spinner />}
           {t("logout")}
         </Button>
-        <DialogClose asChild>
-          <Button
-            type="button"
-            size="sm"
-            className="w-full"
-            disabled={isPending}
-          >
-            {t("cancel")}
-          </Button>
-        </DialogClose>
+        <DialogClose
+          render={
+            <Button
+              type="button"
+              size="sm"
+              className="w-full"
+              disabled={isPending}
+            >
+              {t("cancel")}
+            </Button>
+          }
+        />
       </DialogFooter>
     </DialogContent>
   );

--- a/packages/settings-panel/src/presets/modals/passkeys-modal.tsx
+++ b/packages/settings-panel/src/presets/modals/passkeys-modal.tsx
@@ -32,15 +32,13 @@ export function PasskeysModal() {
     usePasskeys();
 
   return (
-    <DialogContent className="w-100 p-5">
+    <DialogContent className="w-100">
       <DialogHeader>
         <DialogIcon>
           <Icon.LockShield className="size-8 fill-primary/45" />
         </DialogIcon>
         <DialogTitle>{t("title")}</DialogTitle>
-        <DialogDescription className="text-primary">
-          {t("description")}
-        </DialogDescription>
+        <DialogDescription>{t("description")}</DialogDescription>
         {error && <div className="text-xs text-red">{t("error")}</div>}
       </DialogHeader>
       {passkeys.length > 0 && (
@@ -73,16 +71,18 @@ export function PasskeysModal() {
           )}
           {t("add")}
         </Button>
-        <DialogClose asChild>
-          <Button
-            type="button"
-            size="sm"
-            className="w-full"
-            disabled={isPending}
-          >
-            {t("cancel")}
-          </Button>
-        </DialogClose>
+        <DialogClose
+          render={
+            <Button
+              type="button"
+              size="sm"
+              className="w-full"
+              disabled={isPending}
+            >
+              {t("cancel")}
+            </Button>
+          }
+        />
       </DialogFooter>
     </DialogContent>
   );

--- a/packages/settings-panel/src/presets/modals/teamspace-detail/general-content.tsx
+++ b/packages/settings-panel/src/presets/modals/teamspace-detail/general-content.tsx
@@ -100,23 +100,25 @@ export function GeneralContent({
         <Title title={t("danger-zone-title")} />
         <Card className="mb-2.5 flex flex-col hover:bg-red/10">
           <Dialog>
-            <DialogTrigger asChild>
-              <Button
-                tabIndex={-1}
-                variant={null}
-                className="h-11 w-full min-w-0 shrink-0 justify-normal gap-3.5 py-2 text-sm/tight text-red hover:bg-transparent"
-              >
-                <Icon.ArrowLineRight className="size-5 fill-current" />
-                <div className="flex flex-col items-start">
-                  <div className="truncate text-sm/5 text-red">
-                    {t("leave")}
+            <DialogTrigger
+              render={
+                <Button
+                  tabIndex={-1}
+                  variant={null}
+                  className="h-11 w-full min-w-0 shrink-0 justify-normal gap-3.5 py-2 text-sm/tight text-red hover:bg-transparent"
+                >
+                  <Icon.ArrowLineRight className="size-5 fill-current" />
+                  <div className="flex flex-col items-start">
+                    <div className="truncate text-sm/5 text-red">
+                      {t("leave")}
+                    </div>
+                    <div className="overflow-hidden text-xs text-ellipsis whitespace-normal text-secondary">
+                      {t("leave-description")}
+                    </div>
                   </div>
-                  <div className="overflow-hidden text-xs text-ellipsis whitespace-normal text-secondary">
-                    {t("leave-description")}
-                  </div>
-                </div>
-              </Button>
-            </DialogTrigger>
+                </Button>
+              }
+            />
             <LeaveTeamspace name={teamspace.name} onLeave={onLeave} />
           </Dialog>
         </Card>

--- a/packages/settings-panel/src/presets/modals/teamspace-detail/members-content.tsx
+++ b/packages/settings-panel/src/presets/modals/teamspace-detail/members-content.tsx
@@ -111,11 +111,13 @@ export function MembersContent({
               open={openAddTeamMembers}
               onOpenChange={handleAddTeamMembers}
             >
-              <DialogTrigger asChild>
-                <Button variant="blue" size="sm">
-                  {t("add-members")}
-                </Button>
-              </DialogTrigger>
+              <DialogTrigger
+                render={
+                  <Button variant="blue" size="sm">
+                    {t("add-members")}
+                  </Button>
+                }
+              />
               <AddTeamMembers
                 teamspace={teamspace}
                 workspaceMembers={workspaceMembers}

--- a/packages/settings-panel/src/presets/modals/teamspace-detail/teamspace-detail.tsx
+++ b/packages/settings-panel/src/presets/modals/teamspace-detail/teamspace-detail.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 
-import { useTemporaryFix } from "@notion-kit/hooks";
 import { useTranslation } from "@notion-kit/i18n";
 import { Icon } from "@notion-kit/icons";
 import { User } from "@notion-kit/schemas";
@@ -69,17 +68,14 @@ export function TeamspaceDetail({
     keyPrefix: "modals.teamspace-detail",
   });
 
-  const { onCloseAutoFocus } = useTemporaryFix();
   const [tab, setTab] = useState(Tab.Members);
 
   return (
     <TooltipProvider>
       <DialogContent
         className="block h-160 w-[630px] max-w-[unset] overflow-hidden p-9 pt-5"
-        onClick={(e) => e.stopPropagation()}
         hideClose
         noTitle
-        onCloseAutoFocus={onCloseAutoFocus}
       >
         <div className="flex h-[26px] shrink-0 grow-0 items-center gap-2">
           <IconBlock icon={teamspace.icon} size="sm" />
@@ -90,16 +86,18 @@ export function TeamspaceDetail({
           {teamspace.role ? (
             <Dialog>
               <TooltipPreset side="top" description="Click to leave teamspace">
-                <DialogTrigger asChild>
-                  <Button
-                    tabIndex={-1}
-                    variant={null}
-                    className="h-7 rounded-full bg-default/5 px-2.5 hover:bg-default/15"
-                  >
-                    <Icon.Check className="block h-full w-3 fill-current" />
-                    {t("joined")}
-                  </Button>
-                </DialogTrigger>
+                <DialogTrigger
+                  render={
+                    <Button
+                      tabIndex={-1}
+                      variant={null}
+                      className="h-7 rounded-full bg-default/5 px-2.5 hover:bg-default/15"
+                    >
+                      <Icon.Check className="block h-full w-3 fill-current" />
+                      {t("joined")}
+                    </Button>
+                  }
+                />
               </TooltipPreset>
               <LeaveTeamspace name={teamspace.name} onLeave={onLeave} />
             </Dialog>

--- a/packages/settings-panel/src/presets/people/people.tsx
+++ b/packages/settings-panel/src/presets/people/people.tsx
@@ -116,12 +116,14 @@ export function People() {
             title={invite.title}
             description={
               <Dialog>
-                <DialogTrigger asChild>
-                  <TextLinks
-                    i18nKey="people.invite.description"
-                    values={{ guests: guests.length }}
-                  />
-                </DialogTrigger>
+                <DialogTrigger
+                  render={
+                    <TextLinks
+                      i18nKey="people.invite.description"
+                      values={{ guests: guests.length }}
+                    />
+                  }
+                />
                 <AlertModal {...modals["reset-link"]} onTrigger={updateLink} />
               </Dialog>
             }
@@ -246,7 +248,7 @@ export function People() {
             (workspace.plan === Plan.FREE ||
               workspace.plan === Plan.EDUCATION) && (
               <>
-                <section className="max-w-[300px] text-sm">
+                <section className="max-w-75 text-sm">
                   <Icon.Group className="mb-2 h-auto w-8 shrink-0 fill-default/45" />
                   <header className="font-semibold">{upgradeText.title}</header>
                   <p className="mt-1 mb-4 text-secondary">

--- a/packages/settings-panel/src/presets/tables/emojis/index.tsx
+++ b/packages/settings-panel/src/presets/tables/emojis/index.tsx
@@ -112,7 +112,8 @@ export function EmojisTable({
   );
 }
 
-interface AddEmojiDialogProps extends React.PropsWithChildren {
+interface AddEmojiDialogProps {
+  children: React.ReactElement;
   onCreate?: (data: EmojiSchema) => Promise<void>;
 }
 
@@ -121,7 +122,7 @@ function AddEmojiDialog({ children, onCreate }: AddEmojiDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogTrigger render={children} />
       <EmojiForm
         onSave={async ({ name, file }) => {
           if (file) await onCreate?.({ name, file });

--- a/packages/settings-panel/src/presets/tables/sessions/columns.tsx
+++ b/packages/settings-panel/src/presets/tables/sessions/columns.tsx
@@ -101,11 +101,13 @@ const LogoutCell = ({
   const { t } = useTranslation("settings");
   return (
     <Dialog>
-      <DialogTrigger asChild>
-        <Button size="xs" className="h-7 px-2 text-secondary">
-          {t("tables.sessions.actions.logout")}
-        </Button>
-      </DialogTrigger>
+      <DialogTrigger
+        render={
+          <Button size="xs" className="h-7 px-2 text-secondary">
+            {t("tables.sessions.actions.logout")}
+          </Button>
+        }
+      />
       <LogoutConfirm
         title={t("tables.sessions.actions.logout-confirm-title", {
           device: row.original.device,

--- a/packages/settings-panel/src/presets/tables/teamspaces/cells.tsx
+++ b/packages/settings-panel/src/presets/tables/teamspaces/cells.tsx
@@ -179,18 +179,20 @@ export function TeamspaceActionCell({
           {!!role && (
             <>
               <Dialog>
-                <DialogTrigger asChild>
-                  <DropdownMenuItem
-                    variant="error"
-                    icon={<Icon.Bye className="size-4" />}
-                    label={trans.leave}
-                    closeOnClick={false}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }}
-                  />
-                </DialogTrigger>
+                <DialogTrigger
+                  render={
+                    <DropdownMenuItem
+                      variant="error"
+                      icon={<Icon.Bye className="size-4" />}
+                      label={trans.leave}
+                      closeOnClick={false}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                    />
+                  }
+                />
                 <LeaveTeamspace name={name} onLeave={onLeave} />
               </Dialog>
               <DropdownMenuItem

--- a/packages/settings-panel/src/presets/teamspaces/teamspaces-section.tsx
+++ b/packages/settings-panel/src/presets/teamspaces/teamspaces-section.tsx
@@ -54,15 +54,17 @@ export function TeamspacesSection() {
       <Separator />
       <SettingsRule {...trans.manage}>
         <Dialog open={openCreate} onOpenChange={setOpenCreate}>
-          <DialogTrigger>
-            <Button
-              variant="blue"
-              size="sm"
-              disabled={!scopes.has(Scope.TeamspaceCreate)}
-            >
-              {trans.manage.button}
-            </Button>
-          </DialogTrigger>
+          <DialogTrigger
+            render={
+              <Button
+                variant="blue"
+                size="sm"
+                disabled={!scopes.has(Scope.TeamspaceCreate)}
+              >
+                {trans.manage.button}
+              </Button>
+            }
+          />
           <CreateTeamspace
             workspace={workspace.name}
             onClose={() => setOpenCreate(false)}

--- a/packages/table-view/src/common/group-actions.tsx
+++ b/packages/table-view/src/common/group-actions.tsx
@@ -7,7 +7,6 @@ import { AlertModal } from "@notion-kit/ui/alert-modal";
 import {
   Button,
   Dialog,
-  DialogTrigger,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
@@ -78,14 +77,12 @@ export function GroupActions({ className, row }: GroupActionsProps) {
               label="Hide group"
               onClick={row.toggleGroupVisibility}
             />
-            <DialogTrigger asChild>
-              <DropdownMenuItem
-                icon={<Icon.Trash />}
-                label="Delete rows"
-                closeOnClick={false}
-                onClick={() => setShowDeleteConfirm(true)}
-              />
-            </DialogTrigger>
+            <DropdownMenuItem
+              icon={<Icon.Trash />}
+              label="Delete rows"
+              closeOnClick={false}
+              onClick={() => setShowDeleteConfirm(true)}
+            />
           </DropdownMenuGroup>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/table-view/src/common/prop-meta.tsx
+++ b/packages/table-view/src/common/prop-meta.tsx
@@ -68,10 +68,6 @@ export function PropMeta({ propId, type }: PropMetaProps) {
             <div className="flex">
               <Input
                 {...nameField.props}
-                onKeyDown={(e) => {
-                  e.stopPropagation();
-                  nameField.props.onKeyDown?.(e);
-                }}
                 endIcon={
                   <TooltipPreset
                     side="top"
@@ -105,10 +101,6 @@ export function PropMeta({ propId, type }: PropMetaProps) {
             className="text-[13px]/[20px]"
             placeholder="Add a description..."
             {...descField.props}
-            onKeyDown={(e) => {
-              e.stopPropagation();
-              descField.props.onKeyDown?.(e);
-            }}
           />
         </div>
       )}

--- a/packages/table-view/src/menus/select-group-menu.tsx
+++ b/packages/table-view/src/menus/select-group-menu.tsx
@@ -63,7 +63,10 @@ export function SelectGroupMenu() {
         autoHighlight="always"
         openOnInputClick
       >
-        <AutocompleteInput placeholder="Search for a property" />
+        <AutocompleteInput
+          placeholder="Search for a property"
+          onKeyDown={(e) => e.stopPropagation()}
+        />
         <AutocompleteContent role="presentation" variant="inline">
           <AutocompleteList>
             <AutocompleteGroup className="h-40">

--- a/packages/table-view/src/plugins/select/select-config-menu/select-config-menu.tsx
+++ b/packages/table-view/src/plugins/select/select-config-menu/select-config-menu.tsx
@@ -119,13 +119,7 @@ export function SelectConfigMenu({
           {showInput && (
             <div className="mb-2 flex flex-col gap-2 px-3">
               <div className="flex w-full min-w-0 flex-auto items-center select-none">
-                <Input
-                  {...nameField.props}
-                  onKeyDown={(e) => {
-                    e.stopPropagation();
-                    nameField.props.onKeyDown?.(e);
-                  }}
-                />
+                <Input {...nameField.props} />
               </div>
               {nameField.error && (
                 <div className="text-sm text-red">Option already exists.</div>

--- a/packages/table-view/src/plugins/select/select-option-menu/option-meta.tsx
+++ b/packages/table-view/src/plugins/select/select-option-menu/option-meta.tsx
@@ -48,10 +48,6 @@ export function OptionMeta({
         <div className="flex min-h-7 w-full items-center select-none">
           <Input
             {...nameField.props}
-            onKeyDown={(e) => {
-              e.stopPropagation();
-              nameField.props.onKeyDown?.(e);
-            }}
             endIcon={
               <TooltipPreset
                 side="top"
@@ -81,10 +77,6 @@ export function OptionMeta({
             className={cn(typography("body"))}
             placeholder="Add a description..."
             {...descField.props}
-            onKeyDown={(e) => {
-              e.stopPropagation();
-              descField.props.onKeyDown?.(e);
-            }}
           />
         </div>
       )}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -64,8 +64,7 @@
     "react-resizable-panels": "^2.1.7",
     "sonner": "^2.0.7",
     "unsplash-js": "^7.0.19",
-    "usehooks-ts": "catalog:ui",
-    "vaul": "^1.1.2"
+    "usehooks-ts": "catalog:ui"
   },
   "devDependencies": {
     "@notion-kit/config": "workspace:*",

--- a/packages/ui/src/alert-modal/index.tsx
+++ b/packages/ui/src/alert-modal/index.tsx
@@ -34,10 +34,8 @@ export function AlertModal({
 
   return (
     <DialogContent
-      forceMount
       hideClose
-      className="flex w-[300px] flex-col items-start justify-center gap-2 p-6"
-      onClick={(e) => e.stopPropagation()}
+      className="flex w-75 flex-col items-start justify-center gap-2"
       aria-describedby={undefined}
     >
       <DialogHeader>
@@ -56,11 +54,13 @@ export function AlertModal({
           {primary}
           {loading && <Spinner />}
         </Button>
-        <DialogClose asChild>
-          <Button size="sm" className="w-full">
-            {secondary}
-          </Button>
-        </DialogClose>
+        <DialogClose
+          render={
+            <Button size="sm" className="w-full">
+              {secondary}
+            </Button>
+          }
+        />
       </DialogFooter>
     </DialogContent>
   );

--- a/packages/ui/src/icon-menu/_components/menu-search-bar.tsx
+++ b/packages/ui/src/icon-menu/_components/menu-search-bar.tsx
@@ -26,6 +26,7 @@ export const MenuSearchBar: React.FC<MenuSearchBarProps> = ({
             value={search}
             onChange={(e) => onSearchChange(e.target.value)}
             onCancel={() => onSearchChange("")}
+            onKeyDown={(e) => e.stopPropagation()}
             placeholder="Filter..."
           />
         </div>

--- a/packages/ui/src/navbar/presets/history.tsx
+++ b/packages/ui/src/navbar/presets/history.tsx
@@ -46,11 +46,13 @@ export function History({ pageId, fetchLogs }: HistoryProps) {
 
   return (
     <Drawer direction="right" open={open} onOpenChange={setOpen}>
-      <DrawerTrigger asChild>
-        <NavbarItem hint={hint} className="w-7" onClick={handleClick}>
-          <Icon.Clock className="size-5 fill-current" />
-        </NavbarItem>
-      </DrawerTrigger>
+      <DrawerTrigger
+        render={
+          <NavbarItem hint={hint} className="w-7" onClick={handleClick}>
+            <Icon.Clock className="size-5 fill-current" />
+          </NavbarItem>
+        }
+      />
       <DrawerContent side="right" noTitle className="w-90">
         <div className="absolute top-0 left-0 ml-2.5 flex h-12 items-center">
           <TooltipPreset description="Close panel">

--- a/packages/ui/src/primitives/autocomplete.tsx
+++ b/packages/ui/src/primitives/autocomplete.tsx
@@ -9,7 +9,7 @@ import * as _Icon from "./icons";
 import { Input, type InputProps } from "./input";
 import { MenuGroup, MenuItem, MenuLabel } from "./menu";
 import { Separator } from "./separator";
-import { contentVariants } from "./variants";
+import { contentVariants, positioner } from "./variants";
 
 interface AutocompleteGroupItem<ItemValue> {
   items: readonly ItemValue[];
@@ -171,7 +171,7 @@ function AutocompleteContent({
         collisionPadding={collisionPadding}
         side={side}
         sideOffset={sideOffset}
-        className="z-(--z-menu)"
+        className={cn(positioner())}
       >
         <AutocompletePrimitive.Popup
           data-slot="autocomplete-content"

--- a/packages/ui/src/primitives/combobox.tsx
+++ b/packages/ui/src/primitives/combobox.tsx
@@ -9,7 +9,7 @@ import { Button } from "./button";
 import * as _Icon from "./icons";
 import { MenuGroup, MenuItem, MenuItemCheck, MenuLabel } from "./menu";
 import { Separator } from "./separator";
-import { contentVariants } from "./variants";
+import { contentVariants, positioner } from "./variants";
 
 type ComboboxAnchorContextValue = React.RefObject<HTMLElement | null> & {
   ref: React.RefCallback<HTMLElement>;
@@ -159,14 +159,14 @@ function ComboboxContent({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor ?? comboboxAnchor}
-        className="z-(--z-menu)"
+        className={cn(positioner())}
       >
         <ComboboxPrimitive.Popup
           data-slot="combobox-content"
           data-variant={variant}
           className={cn(
-            contentVariants({ variant: "default", openAnimation: true }),
-            "group/combobox-content max-h-[min(calc(var(--available-height)-8px),300px)] w-(--anchor-width) min-w-(--anchor-width) overflow-hidden rounded-md bg-modal",
+            contentVariants({ variant: "popover", openAnimation: true }),
+            "group/combobox-content max-h-[min(calc(var(--available-height)-8px),300px)] w-(--anchor-width) min-w-(--anchor-width) overflow-hidden",
             className,
           )}
           {...props}

--- a/packages/ui/src/primitives/context-menu.tsx
+++ b/packages/ui/src/primitives/context-menu.tsx
@@ -14,7 +14,7 @@ import {
   MenuLabel,
 } from "./menu";
 import { Separator } from "./separator";
-import { contentVariants, MenuItemVariants } from "./variants";
+import { contentVariants, MenuItemVariants, positioner } from "./variants";
 
 function ContextMenu({ ...props }: ContextMenuPrimitive.Root.Props) {
   return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
@@ -189,6 +189,7 @@ function ContextMenuSubContent({
       collisionPadding={collisionPadding}
       side={side}
       sideOffset={sideOffset}
+      className={cn(positioner())}
     >
       <Menu.Popup
         data-slot="context-menu-sub-content"

--- a/packages/ui/src/primitives/design.tsx
+++ b/packages/ui/src/primitives/design.tsx
@@ -1,0 +1,61 @@
+import { cn, cva } from "@notion-kit/cn";
+
+/**
+ * @todo update contentVariant based on this
+ */
+export const content = cva(
+  [
+    cn(
+      "z-50 duration-100",
+      "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+      "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
+    ),
+  ],
+  {
+    variants: {
+      color: {
+        popup:
+          "text-popover-foreground ring-foreground/10 rounded-lg bg-popover shadow-md ring-1 outline-none",
+        tooltip: "bg-foreground text-background",
+      },
+      position: {
+        transform: cn(
+          "origin-(--transform-origin)",
+          "data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
+          "data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2",
+        ),
+        centered: "fixed top-1/2 left-1/2 -translate-1/2",
+      },
+      layout: {
+        list: "max-h-(--available-height) w-(--anchor-width) overflow-x-hidden overflow-y-auto",
+        fullscreen: "w-full max-w-[calc(100%-2rem)] sm:max-w-sm",
+      },
+      type: {
+        // color: popup, position: transform, layout: null
+        popover: cn("flex w-72 flex-col gap-2.5 p-2.5 text-sm"),
+        // color: popup, position: transform, layout: list
+        select: cn(
+          "relative isolate min-w-36 data-[align-trigger=true]:animate-none",
+        ),
+        // color: popup, position: transform,layout: list
+        dropdownMenu: cn("min-w-32 p-1 data-closed:overflow-hidden"),
+        // color: popup, position: transform,layout: list
+        contextMenu: cn("min-w-36 p-1"),
+        // color: popup, position: transform, layout: list
+        combobox: cn(
+          "group/combobox-content relative max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] data-[chips=true]:min-w-(--anchor-width)",
+          "*:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:border-input/30 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:shadow-none",
+        ),
+        // color: popup, position: centered, layout: fullscreen
+        dialog: cn("grid gap-4 rounded-xl p-4 text-sm"),
+        // color: tooltip, position: transform, layout: null
+        tooltip: cn(
+          "inline-flex w-fit max-w-xs items-center gap-1.5 rounded-md px-3 py-1.5 text-xs",
+          "has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm",
+          "data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95",
+        ),
+      },
+    },
+  },
+);

--- a/packages/ui/src/primitives/design.tsx
+++ b/packages/ui/src/primitives/design.tsx
@@ -1,22 +1,22 @@
 import { cn, cva } from "@notion-kit/cn";
 
 /**
- * @todo update contentVariant based on this
+ * @todo migrate contentVariant based on this
  */
 export const content = cva(
   [
     cn(
       "z-50 duration-100",
-      "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
       "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
+      "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
     ),
   ],
   {
     variants: {
       color: {
         popup:
-          "text-popover-foreground ring-foreground/10 rounded-lg bg-popover shadow-md ring-1 outline-none",
-        tooltip: "bg-foreground text-background",
+          "rounded-lg border border-border bg-popover text-primary shadow-md outline-none",
+        tooltip: "rounded-sm bg-tooltip text-tooltip-primary",
       },
       position: {
         transform: cn(
@@ -32,26 +32,61 @@ export const content = cva(
         fullscreen: "w-full max-w-[calc(100%-2rem)] sm:max-w-sm",
       },
       type: {
-        // color: popup, position: transform, layout: null
+        /**
+         * @variation
+         * - color: `popup`
+         * - position: `transform`
+         * - layout: `null`
+         */
         popover: cn("flex w-72 flex-col gap-2.5 p-2.5 text-sm"),
-        // color: popup, position: transform, layout: list
+        /**
+         * @variation
+         * - color: `popup`
+         * - position: `transform`
+         * - layout: `list`
+         */
         select: cn(
           "relative isolate min-w-36 data-[align-trigger=true]:animate-none",
         ),
-        // color: popup, position: transform,layout: list
+        /**
+         * @variation
+         * - color: `popup`
+         * - position: `transform`
+         * - layout: `list`
+         */
         dropdownMenu: cn("min-w-32 p-1 data-closed:overflow-hidden"),
-        // color: popup, position: transform,layout: list
+        /**
+         * @variation
+         * - color: `popup`
+         * - position: `transform`
+         * - layout: `list`
+         */
         contextMenu: cn("min-w-36 p-1"),
-        // color: popup, position: transform, layout: list
+        /**
+         * @variation
+         * - color: `popup`
+         * - position: `transform`
+         * - layout: `list`
+         */
         combobox: cn(
           "group/combobox-content relative max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] data-[chips=true]:min-w-(--anchor-width)",
           "*:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:border-input/30 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:shadow-none",
         ),
-        // color: popup, position: centered, layout: fullscreen
+        /**
+         * @variation
+         * - color: `popup`
+         * - position: `centered`
+         * - layout: `fullscreen`
+         */
         dialog: cn("grid gap-4 rounded-xl p-4 text-sm"),
-        // color: tooltip, position: transform, layout: null
+        /**
+         * @variation
+         * - color: `tooltip`
+         * - position: `transform`
+         * - layout: `null`
+         */
         tooltip: cn(
-          "inline-flex w-fit max-w-xs items-center gap-1.5 rounded-md px-3 py-1.5 text-xs",
+          "inline-flex w-fit max-w-55 items-center gap-1.5 rounded-sm px-2 py-1 text-xs/[1.4] font-medium wrap-break-word",
           "has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm",
           "data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95",
         ),

--- a/packages/ui/src/primitives/dialog.tsx
+++ b/packages/ui/src/primitives/dialog.tsx
@@ -1,108 +1,93 @@
-"use client";
-
 import * as React from "react";
-import { Dialog as DialogPrimitive } from "radix-ui";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 
 import { cn } from "@notion-kit/cn";
 
 import { Button } from "./button";
 import * as Icon from "./icons";
 import { contentVariants, Typography, typography } from "./variants";
-import { VisuallyHidden } from "./visually-hidden";
 
-function Dialog({
+function Dialog<Payload = unknown>({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+}: DialogPrimitive.Root.Props<Payload>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
-function DialogTrigger({
+function DialogTrigger<Payload = unknown>({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+}: DialogPrimitive.Trigger.Props<Payload>) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({
-  asChild,
-  children,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+function DialogClose({ render, ...props }: DialogPrimitive.Close.Props) {
   return (
-    <DialogPrimitive.Close data-slot="dialog-close" asChild>
-      {asChild ? (
-        children
-      ) : (
-        <Button
-          type="button"
-          variant="close"
-          size="circle"
-          aria-label="Close"
-          {...props}
-        >
-          <Icon.Close className="h-full w-3.5 fill-secondary dark:fill-default/45" />
-          <span className="sr-only">Close</span>
-        </Button>
-      )}
-    </DialogPrimitive.Close>
+    <DialogPrimitive.Close
+      data-slot="dialog-close"
+      render={
+        render ?? (
+          <Button
+            type="button"
+            variant="close"
+            size="circle"
+            aria-label="Close"
+          >
+            <Icon.Close className="h-full w-3.5 fill-secondary dark:fill-default/45" />
+            <span className="sr-only">Close</span>
+          </Button>
+        )
+      }
+      {...props}
+    />
   );
 }
 
 function DialogOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+}: DialogPrimitive.Backdrop.Props) {
   return (
-    <DialogPrimitive.Overlay
+    <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
         "fixed inset-0 z-(--z-menu) bg-black/50",
-        "data-[state=open]:animate-in data-[state=open]:fade-in-0",
-        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+        "data-open:animate-in data-open:fade-in-0",
+        "data-closed:animate-out data-closed:fade-out-0",
         className,
       )}
       {...props}
     />
   );
 }
-interface DialogContentProps
-  extends React.ComponentProps<typeof DialogPrimitive.Content> {
+interface DialogContentProps extends DialogPrimitive.Popup.Props {
   hideClose?: boolean;
   noTitle?: boolean;
+  container?: DialogPrimitive.Portal.Props["container"];
 }
 function DialogContent({
   className,
   children,
+  container,
   hideClose = false,
   noTitle,
   ...props
 }: DialogContentProps) {
   return (
-    <DialogPortal>
+    <DialogPortal container={container}>
       <DialogOverlay />
-      <DialogPrimitive.Content
+      <DialogPrimitive.Popup
         data-slot="dialog-content"
-        className={cn(
-          contentVariants({ variant: "modal" }),
-          "rounded-sm",
-          className,
-        )}
+        className={cn(contentVariants({ variant: "modal", className }))}
         {...props}
         {...(noTitle && { "aria-describedby": undefined })}
       >
-        {noTitle && (
-          <VisuallyHidden asChild>
-            <DialogTitle />
-          </VisuallyHidden>
-        )}
+        {noTitle && <DialogTitle className="sr-only" />}
         {children}
         {!hideClose && <DialogClose className={cn("absolute top-4 right-4")} />}
-      </DialogPrimitive.Content>
+      </DialogPrimitive.Popup>
     </DialogPortal>
   );
 }
@@ -147,8 +132,7 @@ function DialogIcon({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-interface DialogTitleProps
-  extends React.ComponentProps<typeof DialogPrimitive.Title> {
+interface DialogTitleProps extends DialogPrimitive.Title.Props {
   typography?: Typography;
 }
 
@@ -171,8 +155,7 @@ function DialogTitle({
   );
 }
 
-interface DialogDescriptionProps
-  extends React.ComponentProps<typeof DialogPrimitive.Description> {
+interface DialogDescriptionProps extends DialogPrimitive.Description.Props {
   typography?: Typography;
 }
 

--- a/packages/ui/src/primitives/drawer.tsx
+++ b/packages/ui/src/primitives/drawer.tsx
@@ -1,53 +1,57 @@
-"use client";
-
 import * as React from "react";
-import { Drawer as DrawerPrimitive } from "vaul";
+import { Drawer as DrawerPrimitive } from "@base-ui/react/drawer";
 
 import { cn } from "@notion-kit/cn";
 
 import { contentVariants } from "./variants";
-import { VisuallyHidden } from "./visually-hidden";
+
+type DrawerDirection = "top" | "right" | "bottom" | "left";
+
+function directionToSwipeDirection(direction?: DrawerDirection) {
+  if (direction === "top") return "up";
+  if (direction === "bottom") return "down";
+  return direction;
+}
 
 function Drawer({
-  shouldScaleBackground = true,
+  direction,
+  shouldScaleBackground: _shouldScaleBackground,
+  swipeDirection,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+}: DrawerPrimitive.Root.Props & {
+  direction?: DrawerDirection;
+  shouldScaleBackground?: boolean;
+}) {
   return (
     <DrawerPrimitive.Root
       data-slot="drawer"
-      shouldScaleBackground={shouldScaleBackground}
+      swipeDirection={swipeDirection ?? directionToSwipeDirection(direction)}
       {...props}
     />
   );
 }
 
-function DrawerTrigger({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+function DrawerTrigger({ ...props }: DrawerPrimitive.Trigger.Props) {
   return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
 }
 
-function DrawerPortal({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+function DrawerPortal({ ...props }: DrawerPrimitive.Portal.Props) {
   return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
 }
 
-function DrawerClose({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+function DrawerClose({ ...props }: DrawerPrimitive.Close.Props) {
   return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
 }
 
 function DrawerOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+}: DrawerPrimitive.Backdrop.Props) {
   return (
-    <DrawerPrimitive.Overlay
+    <DrawerPrimitive.Backdrop
       data-slot="drawer-overlay"
       className={cn(
-        "fixed inset-0 z-(--z-menu) bg-black/80 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-(--z-menu) bg-black/80 data-closed:animate-out data-closed:fade-out-0 data-open:animate-in data-open:fade-in-0",
         className,
       )}
       {...props}
@@ -55,8 +59,7 @@ function DrawerOverlay({
   );
 }
 
-interface DrawerContentProps
-  extends React.ComponentProps<typeof DrawerPrimitive.Content> {
+interface DrawerContentProps extends DrawerPrimitive.Popup.Props {
   side?: "bottom" | "right";
   noTitle?: boolean;
 }
@@ -70,26 +73,25 @@ function DrawerContent({
   return (
     <DrawerPortal>
       <DrawerOverlay className="z-0 bg-transparent" />
-      <DrawerPrimitive.Content
-        data-slot="drawer-content"
-        className={cn(
-          // TODO check and update these styles
-          "fixed inset-x-0 bottom-0 z-(--z-menu) mt-24 flex flex-col rounded-t-[10px]",
-          contentVariants({ variant: "default", openAnimation: false }),
-          side === "right" &&
-            "inset-y-0 right-0 left-auto mt-0 h-screen rounded-none border-t-0 border-r-0",
-          className,
-        )}
-        {...props}
-        {...(noTitle && { "aria-describedby": undefined })}
-      >
-        {noTitle && (
-          <VisuallyHidden asChild>
-            <DrawerTitle />
-          </VisuallyHidden>
-        )}
-        {children}
-      </DrawerPrimitive.Content>
+      <DrawerPrimitive.Viewport className="pointer-events-none fixed inset-0 z-(--z-menu)">
+        <DrawerPrimitive.Popup
+          data-slot="drawer-content"
+          className={cn(
+            "pointer-events-auto fixed inset-x-0 bottom-0 z-(--z-menu) mt-24 flex flex-col rounded-t-[10px]",
+            contentVariants({ variant: "default", openAnimation: false }),
+            side === "right" &&
+              "inset-y-0 right-0 left-auto mt-0 h-screen rounded-none border-t-0 border-r-0",
+            className,
+          )}
+          {...props}
+          {...(noTitle && { "aria-describedby": undefined })}
+        >
+          <DrawerPrimitive.Content>
+            {noTitle && <DrawerTitle className="sr-only" />}
+            {children}
+          </DrawerPrimitive.Content>
+        </DrawerPrimitive.Popup>
+      </DrawerPrimitive.Viewport>
     </DrawerPortal>
   );
 }
@@ -116,10 +118,7 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function DrawerTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+function DrawerTitle({ className, ...props }: DrawerPrimitive.Title.Props) {
   return (
     <DrawerPrimitive.Title
       className={cn(
@@ -134,7 +133,7 @@ function DrawerTitle({
 function DrawerDescription({
   className,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+}: DrawerPrimitive.Description.Props) {
   return (
     <DrawerPrimitive.Description
       className={cn("text-sm text-muted", className)}

--- a/packages/ui/src/primitives/dropdown-menu.tsx
+++ b/packages/ui/src/primitives/dropdown-menu.tsx
@@ -15,7 +15,7 @@ import {
 } from "./menu";
 import { Separator } from "./separator";
 import { Switch } from "./switch";
-import { contentVariants } from "./variants";
+import { contentVariants, positioner } from "./variants";
 
 function DropdownMenu({ ...props }: Menu.Root.Props) {
   return <Menu.Root data-slot="dropdown-menu" {...props} />;
@@ -122,6 +122,7 @@ function DropdownMenuContent({
         collisionPadding={collisionPadding}
         side={side}
         sideOffset={sideOffset}
+        className={cn(positioner())}
       >
         <Menu.Popup
           data-slot="dropdown-menu-content"

--- a/packages/ui/src/primitives/popover.test.tsx
+++ b/packages/ui/src/primitives/popover.test.tsx
@@ -44,20 +44,4 @@ describe("Popover", () => {
 
     expect(screen.queryByText("Closable content")).not.toBeInTheDocument();
   });
-
-  it("keeps Radix-style content compatibility props", () => {
-    render(
-      <Popover defaultOpen>
-        <PopoverTrigger render={<button type="button">Open</button>} />
-        <PopoverContent forceMount sticky="always">
-          Sticky content
-        </PopoverContent>
-      </Popover>,
-    );
-
-    expect(screen.getByText("Sticky content")).toHaveAttribute(
-      "data-slot",
-      "popover-content",
-    );
-  });
 });

--- a/packages/ui/src/primitives/popover.tsx
+++ b/packages/ui/src/primitives/popover.tsx
@@ -4,7 +4,7 @@ import { cn } from "@notion-kit/cn";
 
 import { Button } from "./button";
 import * as Icon from "./icons";
-import { contentVariants } from "./variants";
+import { contentVariants, positioner } from "./variants";
 
 function Popover<Payload = unknown>({
   modal = false,
@@ -43,9 +43,7 @@ type PopoverPositionerProps = Pick<
   | "positionMethod"
   | "side"
   | "sideOffset"
-> & {
-  sticky?: PopoverPrimitive.Positioner.Props["sticky"] | "always" | "partial";
-};
+>;
 
 type PopoverContentProps = PopoverPrimitive.Popup.Props &
   PopoverPositionerProps & {
@@ -63,7 +61,6 @@ function PopoverContent({
   positionMethod,
   side,
   sideOffset = 4,
-  sticky,
   finalFocus = false,
   ...props
 }: PopoverContentProps) {
@@ -78,7 +75,7 @@ function PopoverContent({
         positionMethod={positionMethod}
         side={side}
         sideOffset={sideOffset}
-        sticky={typeof sticky === "string" ? true : sticky}
+        className={cn(positioner())}
       >
         <PopoverPrimitive.Popup
           data-slot="popover-content"

--- a/packages/ui/src/primitives/popover.tsx
+++ b/packages/ui/src/primitives/popover.tsx
@@ -50,7 +50,6 @@ type PopoverPositionerProps = Pick<
 type PopoverContentProps = PopoverPrimitive.Popup.Props &
   PopoverPositionerProps & {
     container?: PopoverPrimitive.Portal.Props["container"];
-    forceMount?: boolean;
   };
 
 function PopoverContent({
@@ -61,7 +60,6 @@ function PopoverContent({
   collisionBoundary,
   collisionPadding,
   container,
-  forceMount,
   positionMethod,
   side,
   sideOffset = 4,
@@ -70,7 +68,7 @@ function PopoverContent({
   ...props
 }: PopoverContentProps) {
   return (
-    <PopoverPrimitive.Portal container={container} keepMounted={forceMount}>
+    <PopoverPrimitive.Portal container={container}>
       <PopoverPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}

--- a/packages/ui/src/primitives/select.tsx
+++ b/packages/ui/src/primitives/select.tsx
@@ -9,6 +9,7 @@ import { Separator } from "./separator";
 import {
   buttonVariants,
   contentVariants,
+  positioner,
   type MenuItemVariants,
 } from "./variants";
 
@@ -123,6 +124,7 @@ function SelectContent({
         collisionPadding={collisionPadding}
         side={side}
         sideOffset={sideOffset}
+        className={cn(positioner())}
       >
         <SelectPrimitive.Popup
           data-slot="select-content"

--- a/packages/ui/src/primitives/sheet.tsx
+++ b/packages/ui/src/primitives/sheet.tsx
@@ -1,53 +1,56 @@
-"use client";
-
 import * as React from "react";
-import { Dialog as SheetPrimitive } from "radix-ui";
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
 
 import { cn } from "@notion-kit/cn";
 
 import { Button } from "./button";
 import * as Icon from "./icons";
 import { contentVariants, Typography, typography } from "./variants";
-import { VisuallyHidden } from "./visually-hidden";
 
-function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+function Sheet<Payload = unknown>({
+  ...props
+}: SheetPrimitive.Root.Props<Payload>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
 
-function SheetTrigger({
+function SheetTrigger<Payload = unknown>({
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+}: SheetPrimitive.Trigger.Props<Payload>) {
   return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
 }
 
-function SheetClose({
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+function SheetClose({ render, ...props }: SheetPrimitive.Close.Props) {
   return (
-    <SheetPrimitive.Close data-slot="sheet-close" asChild>
-      <Button type="button" variant="close" size="circle" {...props}>
-        <Icon.Close className="h-full w-3.5 fill-secondary dark:fill-default/45" />
-        <span className="sr-only">Close</span>
-      </Button>
-    </SheetPrimitive.Close>
+    <SheetPrimitive.Close
+      data-slot="sheet-close"
+      render={
+        render ?? (
+          <Button
+            type="button"
+            variant="close"
+            size="circle"
+            aria-label="Close"
+          >
+            <Icon.Close className="h-full w-3.5 fill-secondary dark:fill-default/45" />
+            <span className="sr-only">Close</span>
+          </Button>
+        )
+      }
+      {...props}
+    />
   );
 }
 
-function SheetPortal({
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
   return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
 }
 
-function SheetOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
   return (
-    <SheetPrimitive.Overlay
+    <SheetPrimitive.Backdrop
       data-slot="sheet-overlay"
       className={cn(
-        "fixed inset-0 z-(--z-menu) bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-(--z-menu) bg-black/50 data-closed:animate-out data-closed:fade-out-0 data-open:animate-in data-open:fade-in-0",
         className,
       )}
       {...props}
@@ -55,12 +58,11 @@ function SheetOverlay({
   );
 }
 
-interface SheetContentProps
-  extends React.ComponentProps<typeof SheetPrimitive.Content> {
+interface SheetContentProps extends SheetPrimitive.Popup.Props {
   side?: "top" | "right" | "bottom" | "left";
   hideClose?: boolean;
   hasOverlay?: boolean;
-  container?: Element | DocumentFragment | null;
+  container?: SheetPrimitive.Portal.Props["container"];
 }
 
 function SheetContent({
@@ -70,39 +72,36 @@ function SheetContent({
   hideClose,
   hasOverlay = true,
   container,
+
   ...props
 }: SheetContentProps) {
   return (
     <SheetPortal container={container}>
       {hasOverlay && <SheetOverlay />}
-      <VisuallyHidden asChild>
-        <SheetPrimitive.Title />
-      </VisuallyHidden>
-      <VisuallyHidden asChild>
-        <SheetPrimitive.Description />
-      </VisuallyHidden>
-      <SheetPrimitive.Content
+      <SheetPrimitive.Title className="sr-only" />
+      <SheetPrimitive.Description className="sr-only" />
+      <SheetPrimitive.Popup
         data-slot="sheet-content"
         className={cn(
           contentVariants({ variant: "sheet" }),
-          "flex flex-col gap-4 transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-300",
+          "flex flex-col gap-4 transition ease-in-out data-closed:animate-out data-closed:duration-300 data-open:animate-in data-open:duration-300",
           side === "right" &&
-            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+            "inset-y-0 right-0 h-full w-3/4 border-l data-closed:slide-out-to-right data-open:slide-in-from-right sm:max-w-sm",
           side === "left" &&
-            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+            "inset-y-0 left-0 h-full w-3/4 border-r data-closed:slide-out-to-left data-open:slide-in-from-left sm:max-w-sm",
           side === "top" &&
-            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+            "inset-x-0 top-0 h-auto border-b data-closed:slide-out-to-top data-open:slide-in-from-top",
           side === "bottom" &&
-            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+            "inset-x-0 bottom-0 h-auto border-t data-closed:slide-out-to-bottom data-open:slide-in-from-bottom",
           className,
         )}
         {...props}
       >
         {children}
         {!hideClose && (
-          <SheetClose className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-main transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary" />
+          <SheetClose className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-main transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-open:bg-secondary" />
         )}
-      </SheetPrimitive.Content>
+      </SheetPrimitive.Popup>
     </SheetPortal>
   );
 }
@@ -127,8 +126,7 @@ function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-interface SheetTitleProps
-  extends React.ComponentProps<typeof SheetPrimitive.Title> {
+interface SheetTitleProps extends SheetPrimitive.Title.Props {
   typography?: Typography;
 }
 
@@ -154,7 +152,7 @@ function SheetTitle({
 function SheetDescription({
   className,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+}: SheetPrimitive.Description.Props) {
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"

--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -1,15 +1,9 @@
-"use client";
-
 import * as React from "react";
 import { Tooltip as TooltipPrimitive } from "radix-ui";
 
 import { cn } from "@notion-kit/cn";
 
-import {
-  contentVariants,
-  tooltipVariants,
-  type TooltipVariants,
-} from "./variants";
+import { contentVariants, tooltipVariants } from "./variants";
 
 function TooltipProvider({
   ...props
@@ -34,11 +28,9 @@ function TooltipTrigger({
 
 type TooltipContentProps = React.ComponentProps<
   typeof TooltipPrimitive.Content
-> &
-  TooltipVariants;
+>;
 function TooltipContent({
   className,
-  size,
   sideOffset = 4,
   ...props
 }: TooltipContentProps) {
@@ -49,7 +41,7 @@ function TooltipContent({
         sideOffset={sideOffset}
         className={cn(
           contentVariants({ variant: "tooltip", sideAnimation: true }),
-          tooltipVariants({ size }),
+          tooltipVariants(),
           className,
         )}
         {...props}

--- a/packages/ui/src/primitives/variants.ts
+++ b/packages/ui/src/primitives/variants.ts
@@ -146,7 +146,7 @@ export const contentVariants = cva(
          * @note Used with: `openAnimation`
          */
         modal:
-          "fixed top-1/2 left-1/2 z-(--z-menu) grid w-full max-w-lg -translate-1/2 gap-4 bg-modal p-6 shadow-lg duration-200",
+          "fixed top-1/2 left-1/2 z-(--z-menu) grid w-full max-w-lg -translate-1/2 gap-4 rounded-lg bg-modal p-6 shadow-lg duration-200",
         /**
          * @prop popover
          * @note Used by: DropdownMenu, Popover, Select

--- a/packages/ui/src/primitives/variants.ts
+++ b/packages/ui/src/primitives/variants.ts
@@ -130,6 +130,9 @@ export const inputVariants = cva(
 );
 export type InputVariants = VariantProps<typeof inputVariants>;
 
+/**
+ * @todo migrate to the new styles in `./design`
+ */
 export const contentVariants = cva(
   "border border-border text-primary focus-visible:outline-hidden",
   {
@@ -197,17 +200,7 @@ export type SeparatorVariants = VariantProps<typeof separatorVariants>;
 export const groupVariants = cva("flex flex-col gap-px py-1");
 
 export const tooltipVariants = cva(
-  "max-w-[220px] font-medium wrap-break-word",
-  {
-    variants: {
-      size: {
-        sm: "rounded-sm px-2 py-1 text-xs/[1.4]",
-        md: "rounded-md px-3 py-1.5 text-sm",
-      },
-    },
-    defaultVariants: { size: "sm" },
-  },
+  "max-w-55 rounded-sm px-2 py-1 text-xs/[1.4] font-medium wrap-break-word",
 );
-export type TooltipVariants = VariantProps<typeof tooltipVariants>;
 
 export const positioner = cva("isolate z-(--z-menu) outline-none");

--- a/packages/ui/src/primitives/variants.ts
+++ b/packages/ui/src/primitives/variants.ts
@@ -209,3 +209,5 @@ export const tooltipVariants = cva(
   },
 );
 export type TooltipVariants = VariantProps<typeof tooltipVariants>;
+
+export const positioner = cva("isolate z-(--z-menu) outline-none");

--- a/packages/ui/src/sidebar/presets/trash-box.tsx
+++ b/packages/ui/src/sidebar/presets/trash-box.tsx
@@ -69,7 +69,6 @@ export function TrashBox({
           }
         />
         <PopoverContent
-          forceMount
           className="relative bottom-10 flex h-[50vh] w-100 flex-col"
           side="right"
           sideOffset={-4}
@@ -121,16 +120,18 @@ export function TrashBox({
                       </TooltipPreset>
                       <Dialog>
                         <TooltipPreset description="Delete from Trash">
-                          <DialogTrigger asChild>
-                            <Button
-                              variant="hint"
-                              className="size-5"
-                              aria-label="Delete from Trash"
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              <Icon.Trash className="size-4" />
-                            </Button>
-                          </DialogTrigger>
+                          <DialogTrigger
+                            render={
+                              <Button
+                                variant="hint"
+                                className="size-5"
+                                aria-label="Delete from Trash"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <Icon.Trash className="size-4" />
+                              </Button>
+                            }
+                          />
                         </TooltipPreset>
                         <AlertModal
                           title="Are you sure you want to delete this page from Trash?"

--- a/packages/ui/tsdown.config.ts
+++ b/packages/ui/tsdown.config.ts
@@ -28,7 +28,6 @@ const THIRD_PARTY = [
   "sonner",
   "unsplash-js",
   "usehooks-ts",
-  "vaul",
 ];
 
 export default defineConfig((opts) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1897,9 +1897,6 @@ importers:
       usehooks-ts:
         specifier: catalog:ui
         version: 3.1.1(react@19.2.3)
-      vaul:
-        specifier: ^1.1.2
-        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -11319,12 +11316,6 @@ packages:
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  vaul@1.1.2:
-    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
-    peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-message@4.0.2:
     resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
@@ -21558,15 +21549,6 @@ snapshots:
       typescript: 6.0.3
 
   validate-npm-package-name@5.0.1: {}
-
-  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
 
   vfile-message@4.0.2:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrated `Dialog`, `Sheet`, and `Drawer` to `@base-ui` and removed Radix/Vaul APIs. Standardized triggers/closes, unified z-index with a shared positioner, and stopped input key events from leaking into menus/dialogs.

- **Migration**
  - Replace `<DialogTrigger asChild>` with `<DialogTrigger render={<Button ... />} />` (same for `DrawerTrigger`, `SheetTrigger`).
  - Replace `<DialogClose asChild>` with `<DialogClose render={<Button ... />} />` (same for `SheetClose`).
  - Remove `forceMount` (and `sticky`) from popovers/menus; rely on default mounting.
  - Use `finalFocus={() => true}` instead of `onCloseAutoFocus` where needed.
  - For `Drawer`, use `direction="top|right|bottom|left"` or set `swipeDirection`.
  - Add shared `positioner` to `Popover`, `DropdownMenu`, `Select`, `Combobox`, `Autocomplete`, and `ContextMenu` for consistent stacking.
  - `DialogContent`/`SheetContent` support an optional `container` for custom portal mounting.
  - Simplified tooltip styles; removed size prop from `TooltipContent`.
  - Remove `vaul` from `packages/ui` and build config; updated lockfile.

- **Bug Fixes**
  - Fixed z-index issues by applying the shared `positioner()` to all popups and submenus.
  - Prevent input key events from propagating into parent menus/dialogs: centralized in `useInputField` and applied to search/autocomplete inputs.

<sup>Written for commit babf237e12f81e071f1dcf054c6fbc213ca1f167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/steeeee0223/notion-kit/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

