### PR TITLE
feat: update table api usage

### DIFF
--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -37,8 +37,8 @@
     "react-dom": "catalog:react19"
   },
   "devDependencies": {
-    "@ampproject/remapping": "catalog:test",
-    "@jridgewell/trace-mapping": "catalog:test",
+    "@ampproject/remapping": "^2.3.0",
+    "@jridgewell/trace-mapping": "^0.3.31",
     "@notion-kit/eslint-config": "workspace:*",
     "@notion-kit/prettier-config": "workspace:*",
     "@notion-kit/tsconfig": "workspace:*",
@@ -51,7 +51,7 @@
     "@vitejs/plugin-react": "catalog:test",
     "eslint": "catalog:",
     "jsdom": "catalog:rtl",
-    "monocart-coverage-reports": "catalog:test",
+    "monocart-coverage-reports": "^2.11.5",
     "prettier": "catalog:",
     "tailwindcss": "catalog:tailwind-v4",
     "typescript": "catalog:",

--- a/packages/table-hook/package.json
+++ b/packages/table-hook/package.json
@@ -40,8 +40,8 @@
     "@dnd-kit/react": "catalog:ui",
     "@notion-kit/cn": "workspace:*",
     "@notion-kit/ui": "workspace:*",
-    "@tanstack/react-table": "v9.0.0-beta.38",
-    "@tanstack/table-core": "9.0.0-beta.38",
+    "@tanstack/react-table": "v9.0.0-beta.58",
+    "@tanstack/table-core": "9.0.0-beta.58",
     "uuid": "catalog:uuid"
   },
   "devDependencies": {

--- a/packages/table-hook/src/__tests__/columns-info.test.tsx
+++ b/packages/table-hook/src/__tests__/columns-info.test.tsx
@@ -60,7 +60,7 @@ describe("useTableView - Column Custom APIs", () => {
         { initialProps: { properties: mockProperties } },
       );
 
-      expect(result.current.table.store.state.columnOrder).toEqual([
+      expect(result.current.table.atoms.columnOrder.get()).toEqual([
         "col1",
         "col2",
       ]);
@@ -78,7 +78,7 @@ describe("useTableView - Column Custom APIs", () => {
         ],
       });
 
-      expect(result.current.table.store.state.columnOrder).toEqual([
+      expect(result.current.table.atoms.columnOrder.get()).toEqual([
         "col1",
         "col2",
         "col3",
@@ -101,7 +101,7 @@ describe("useTableView - Column Custom APIs", () => {
         });
       });
 
-      const columnOrder = table.store.state.columnOrder;
+      const columnOrder = table.atoms.columnOrder.get();
       expect(columnOrder).toContain("col3");
       expect(columnOrder[columnOrder.length - 1]).toBe("col3");
     });
@@ -121,7 +121,7 @@ describe("useTableView - Column Custom APIs", () => {
         });
       });
 
-      const columnOrder = table.store.state.columnOrder;
+      const columnOrder = table.atoms.columnOrder.get();
       const col1Index = columnOrder.indexOf("col1");
       const col3Index = columnOrder.indexOf("col3");
 
@@ -143,7 +143,7 @@ describe("useTableView - Column Custom APIs", () => {
         });
       });
 
-      const columnOrder = table.store.state.columnOrder;
+      const columnOrder = table.atoms.columnOrder.get();
       const col2Index = columnOrder.indexOf("col2");
       const col3Index = columnOrder.indexOf("col3");
 
@@ -188,7 +188,7 @@ describe("useTableView - Column Custom APIs", () => {
         });
       }).toThrow('[TableView] Column already exists: "col1"');
 
-      expect(table.store.state.columnOrder).toEqual(["col1", "col2"]);
+      expect(table.atoms.columnOrder.get()).toEqual(["col1", "col2"]);
       expect(table.getRow("row1").original.properties.col1).toBe(originalValue);
     });
 
@@ -207,7 +207,7 @@ describe("useTableView - Column Custom APIs", () => {
         });
       });
 
-      expect(table.store.state.columnOrder).toEqual(["col1", "col2", "col3"]);
+      expect(table.atoms.columnOrder.get()).toEqual(["col1", "col2", "col3"]);
     });
   });
 
@@ -222,7 +222,7 @@ describe("useTableView - Column Custom APIs", () => {
         table.removeColumnInfo("col2");
       });
 
-      const columnOrder = table.store.state.columnOrder;
+      const columnOrder = table.atoms.columnOrder.get();
       expect(columnOrder).not.toContain("col2");
     });
 
@@ -236,7 +236,7 @@ describe("useTableView - Column Custom APIs", () => {
         table.removeColumnInfo("col2");
       });
 
-      const columnsInfo = table.store.state.columnsInfo;
+      const columnsInfo = table.atoms.columnsInfo.get();
       expect(columnsInfo.col2).toBeUndefined();
     });
 
@@ -263,13 +263,13 @@ describe("useTableView - Column Custom APIs", () => {
         data: mockData,
         properties: mockProperties,
       });
-      const originalLength = table.store.state.columnOrder.length;
+      const originalLength = table.atoms.columnOrder.get().length;
 
       act(() => {
         table.duplicateColumnInfo("col1");
       });
 
-      const columnOrder = table.store.state.columnOrder;
+      const columnOrder = table.atoms.columnOrder.get();
       expect(columnOrder.length).toBe(originalLength + 1);
     });
 
@@ -283,7 +283,7 @@ describe("useTableView - Column Custom APIs", () => {
         table.duplicateColumnInfo("col1");
       });
 
-      const columnOrder = table.store.state.columnOrder;
+      const columnOrder = table.atoms.columnOrder.get();
       const col1Index = columnOrder.indexOf("col1");
       const duplicateId = columnOrder[col1Index + 1];
 
@@ -301,9 +301,9 @@ describe("useTableView - Column Custom APIs", () => {
         table.duplicateColumnInfo("col1");
       });
 
-      const columnOrder = table.store.state.columnOrder;
+      const columnOrder = table.atoms.columnOrder.get();
       const duplicateId = columnOrder[1]; // Should be right after col1
-      const duplicateInfo = table.store.state.columnsInfo[duplicateId!];
+      const duplicateInfo = table.atoms.columnsInfo.get()[duplicateId!];
 
       expect(duplicateInfo?.name).not.toBe("Name");
       expect(duplicateInfo?.name).toContain("Name");
@@ -320,9 +320,9 @@ describe("useTableView - Column Custom APIs", () => {
         table.duplicateColumnInfo("col1");
       });
 
-      const columnOrder = table.store.state.columnOrder;
+      const columnOrder = table.atoms.columnOrder.get();
       const duplicateId = columnOrder[1];
-      const duplicateInfo = table.store.state.columnsInfo[duplicateId!];
+      const duplicateInfo = table.atoms.columnsInfo.get()[duplicateId!];
 
       expect(duplicateInfo?.type).toBe(originalInfo.type);
     });
@@ -337,7 +337,7 @@ describe("useTableView - Column Custom APIs", () => {
         table.duplicateColumnInfo("col1");
       });
 
-      const columnOrder = table.store.state.columnOrder;
+      const columnOrder = table.atoms.columnOrder.get();
       const duplicateId = columnOrder[1];
       const rows = table.getRowModel().rows;
 
@@ -368,7 +368,7 @@ describe("useTableView - Column Custom APIs", () => {
       });
 
       expect(onPropertiesChange).not.toHaveBeenCalled();
-      expect(table.store.state.columnOrder).toEqual(["col1", "col2"]);
+      expect(table.atoms.columnOrder.get()).toEqual(["col1", "col2"]);
     });
 
     it.each([
@@ -395,7 +395,7 @@ describe("useTableView - Column Custom APIs", () => {
       });
 
       expect(onPropertiesChange).not.toHaveBeenCalled();
-      expect(table.store.state.columnOrder).toEqual(["col1", "col2"]);
+      expect(table.atoms.columnOrder.get()).toEqual(["col1", "col2"]);
     });
 
     it("ColumnDrag_DifferentTarget_EmitsExactPropertyMove", () => {
@@ -423,7 +423,7 @@ describe("useTableView - Column Custom APIs", () => {
         } as DragEndEvent);
       });
 
-      const columnOrder = table.store.state.columnOrder;
+      const columnOrder = table.atoms.columnOrder.get();
       // col1 should have moved after col2
       const col1Index = columnOrder.indexOf("col1");
       const col2Index = columnOrder.indexOf("col2");
@@ -458,7 +458,7 @@ describe("useTableView - Column Custom APIs", () => {
         } as DragEndEvent);
       });
 
-      const columnOrder = table.store.state.columnOrder;
+      const columnOrder = table.atoms.columnOrder.get();
       expect(columnOrder[0]).toBe("col2");
     });
   });

--- a/packages/table-hook/src/__tests__/freezing.test.tsx
+++ b/packages/table-hook/src/__tests__/freezing.test.tsx
@@ -83,7 +83,7 @@ describe("useTableView - Freezing Feature", () => {
       });
 
       expect(table.getFreezingState()).toEqual({ colId: "col2", index: 1 });
-      expect(table.store.state.columnPinning.start).toEqual(["col1", "col2"]);
+      expect(table.atoms.columnPinning.get().start).toEqual(["col1", "col2"]);
     });
 
     it("should clear freezing when set to null", () => {
@@ -208,7 +208,7 @@ describe("useTableView - Freezing Feature", () => {
         table.setColumnFreezing({ colId: "col1", index: 0 });
       });
 
-      const columnPinning = table.store.state.columnPinning;
+      const columnPinning = table.atoms.columnPinning.get();
       expect(columnPinning.start).toEqual(["col1"]);
     });
 
@@ -222,7 +222,7 @@ describe("useTableView - Freezing Feature", () => {
         table.setColumnFreezing({ colId: "col2", index: 1 });
       });
 
-      const columnPinning = table.store.state.columnPinning;
+      const columnPinning = table.atoms.columnPinning.get();
       expect(columnPinning.start).toEqual(["col1", "col2"]);
     });
 
@@ -236,13 +236,13 @@ describe("useTableView - Freezing Feature", () => {
         table.setColumnFreezing({ colId: "col1", index: 0 });
       });
 
-      expect(table.store.state.columnPinning.start).toHaveLength(1);
+      expect(table.atoms.columnPinning.get().start).toHaveLength(1);
 
       act(() => {
         table.setColumnFreezing(null);
       });
 
-      const columnPinning = table.store.state.columnPinning;
+      const columnPinning = table.atoms.columnPinning.get();
       expect(columnPinning.start).toEqual([]);
     });
 
@@ -257,7 +257,7 @@ describe("useTableView - Freezing Feature", () => {
         table.setColumnFreezing({ colId: "col1", index: 0 });
       });
 
-      expect(table.store.state.columnPinning).toEqual({
+      expect(table.atoms.columnPinning.get()).toEqual({
         start: ["col1"],
         end: ["col3"],
       });
@@ -274,7 +274,7 @@ describe("useTableView - Freezing Feature", () => {
       });
 
       expect(table.getFreezingState()).toBeNull();
-      expect(table.store.state.columnPinning.start).toEqual([]);
+      expect(table.atoms.columnPinning.get().start).toEqual([]);
     });
   });
 

--- a/packages/table-hook/src/__tests__/grouping.test.tsx
+++ b/packages/table-hook/src/__tests__/grouping.test.tsx
@@ -58,7 +58,7 @@ describe("useTableView - Extended Grouping", () => {
         data: mockData,
         properties: mockProperties,
       });
-      const groupingState = table.store.state.groupingState;
+      const groupingState = table.atoms.groupingState.get();
 
       expect(groupingState.groupOrder).toEqual([]);
       expect(groupingState.groupVisibility).toEqual({});
@@ -72,13 +72,13 @@ describe("useTableView - Extended Grouping", () => {
         data: mockData,
         properties: mockProperties,
       });
-      const initialGroupOrder = table.store.state.groupingState.groupOrder;
+      const initialGroupOrder = table.atoms.groupingState.get().groupOrder;
 
       act(() => {
         table.setGrouping(["col2"]);
       });
 
-      const groupingState = table.store.state.groupingState;
+      const groupingState = table.atoms.groupingState.get();
       expect(groupingState.groupOrder).not.toBe(initialGroupOrder);
       expect(initialGroupOrder).toEqual([]);
       expect(groupingState.groupOrder.length).toBeGreaterThan(0);
@@ -94,7 +94,7 @@ describe("useTableView - Extended Grouping", () => {
         table.setGrouping(["col2"]);
       });
 
-      const groupingState = table.store.state.groupingState;
+      const groupingState = table.atoms.groupingState.get();
       expect(Object.keys(groupingState.groupValues).length).toBeGreaterThan(0);
     });
 
@@ -108,7 +108,7 @@ describe("useTableView - Extended Grouping", () => {
         table.setGrouping(["col2"]);
       });
 
-      const groupingState = table.store.state.groupingState;
+      const groupingState = table.atoms.groupingState.get();
       const groupIds = groupingState.groupOrder;
 
       groupIds.forEach((groupId) => {
@@ -145,18 +145,18 @@ describe("useTableView - Extended Grouping", () => {
         table.setGrouping(["col2"]);
       });
 
-      const hiddenGroupId = table.store.state.groupingState.groupOrder[0]!;
+      const hiddenGroupId = table.atoms.groupingState.get().groupOrder[0]!;
 
       act(() => {
         table.toggleGroupVisible(hiddenGroupId);
         table.setGrouping(["col2"]);
       });
 
-      expect(table.store.state.groupingState.groupOrder).toContain(
+      expect(table.atoms.groupingState.get().groupOrder).toContain(
         hiddenGroupId,
       );
       expect(
-        table.store.state.groupingState.groupValues[hiddenGroupId],
+        table.atoms.groupingState.get().groupValues[hiddenGroupId],
       ).toBeDefined();
     });
   });
@@ -172,20 +172,20 @@ describe("useTableView - Extended Grouping", () => {
         table.setGrouping(["col2"]);
       });
 
-      const groupId = table.store.state.groupingState.groupOrder[0]!;
+      const groupId = table.atoms.groupingState.get().groupOrder[0]!;
 
       act(() => {
         table.toggleGroupVisible(groupId);
       });
 
-      const groupVisibility = table.store.state.groupingState.groupVisibility;
+      const groupVisibility = table.atoms.groupingState.get().groupVisibility;
       expect(groupVisibility[groupId]).toBe(false);
 
       act(() => {
         table.toggleGroupVisible(groupId);
       });
 
-      const updatedVisibility = table.store.state.groupingState.groupVisibility;
+      const updatedVisibility = table.atoms.groupingState.get().groupVisibility;
       expect(updatedVisibility[groupId]).toBe(true);
     });
 
@@ -203,7 +203,7 @@ describe("useTableView - Extended Grouping", () => {
       expect(table.getIsSomeGroupVisible()).toBe(true);
 
       // Hide all groups
-      const groupIds = table.store.state.groupingState.groupOrder;
+      const groupIds = table.atoms.groupingState.get().groupOrder;
       act(() => {
         groupIds.forEach((groupId) => {
           table.toggleGroupVisible(groupId);
@@ -223,14 +223,14 @@ describe("useTableView - Extended Grouping", () => {
         table.setGrouping(["col2"]);
       });
 
-      const groupIds = table.store.state.groupingState.groupOrder;
+      const groupIds = table.atoms.groupingState.get().groupOrder;
 
       // Hide all
       act(() => {
         table.toggleAllGroupsVisible();
       });
 
-      const hiddenVisibility = table.store.state.groupingState.groupVisibility;
+      const hiddenVisibility = table.atoms.groupingState.get().groupVisibility;
       groupIds.forEach((groupId) => {
         expect(hiddenVisibility[groupId]).toBe(false);
       });
@@ -240,7 +240,7 @@ describe("useTableView - Extended Grouping", () => {
         table.toggleAllGroupsVisible();
       });
 
-      const shownVisibility = table.store.state.groupingState.groupVisibility;
+      const shownVisibility = table.atoms.groupingState.get().groupVisibility;
       groupIds.forEach((groupId) => {
         expect(shownVisibility[groupId]).toBe(true);
       });
@@ -254,13 +254,13 @@ describe("useTableView - Extended Grouping", () => {
         properties: mockProperties,
       });
 
-      const initialState = table.store.state.groupingState.hideEmptyGroups;
+      const initialState = table.atoms.groupingState.get().hideEmptyGroups;
 
       act(() => {
         table.toggleHideEmptyGroups();
       });
 
-      const toggledState = table.store.state.groupingState.hideEmptyGroups;
+      const toggledState = table.atoms.groupingState.get().hideEmptyGroups;
       expect(toggledState).toBe(!initialState);
     });
 
@@ -269,7 +269,7 @@ describe("useTableView - Extended Grouping", () => {
         data: mockData,
         properties: mockProperties,
       });
-      expect(table.store.state.groupingState.hideEmptyGroups).toBe(true);
+      expect(table.atoms.groupingState.get().hideEmptyGroups).toBe(true);
     });
   });
 
@@ -352,7 +352,7 @@ describe("useTableView - Extended Grouping", () => {
         table.setGroupingColumn("col2");
       });
 
-      const grouping = table.store.state.grouping;
+      const grouping = table.atoms.grouping.get();
       expect(grouping).toEqual(["col2"]);
     });
 
@@ -366,13 +366,13 @@ describe("useTableView - Extended Grouping", () => {
         table.setGroupingColumn("col2");
       });
 
-      expect(table.store.state.grouping).toHaveLength(1);
+      expect(table.atoms.grouping.get()).toHaveLength(1);
 
       act(() => {
         table.setGroupingColumn(null);
       });
 
-      expect(table.store.state.grouping).toEqual([]);
+      expect(table.atoms.grouping.get()).toEqual([]);
     });
 
     it("should reset grouping state when changing grouping column", () => {
@@ -385,14 +385,14 @@ describe("useTableView - Extended Grouping", () => {
         table.setGroupingColumn("col2");
       });
 
-      const firstGroupOrder = table.store.state.groupingState.groupOrder;
+      const firstGroupOrder = table.atoms.groupingState.get().groupOrder;
       expect(firstGroupOrder.length).toBeGreaterThan(0);
 
       act(() => {
         table.setGroupingColumn(null);
       });
 
-      const clearedGroupOrder = table.store.state.groupingState.groupOrder;
+      const clearedGroupOrder = table.atoms.groupingState.get().groupOrder;
       expect(clearedGroupOrder).toEqual([]);
     });
 
@@ -406,7 +406,7 @@ describe("useTableView - Extended Grouping", () => {
         table.setGrouping(["col2"]);
       });
 
-      expect(table.store.state.groupingState.groupOrder.length).toBeGreaterThan(
+      expect(table.atoms.groupingState.get().groupOrder.length).toBeGreaterThan(
         0,
       );
 
@@ -414,18 +414,18 @@ describe("useTableView - Extended Grouping", () => {
         table.resetGrouping();
       });
 
-      expect(table.store.state.groupingState.groupOrder).toEqual([]);
-      expect(table.store.state.groupingState.groupValues).toEqual({});
+      expect(table.atoms.groupingState.get().groupOrder).toEqual([]);
+      expect(table.atoms.groupingState.get().groupValues).toEqual({});
 
       act(() => {
         table.setGrouping(["col2"]);
       });
 
-      expect(table.store.state.groupingState.groupOrder.length).toBeGreaterThan(
+      expect(table.atoms.groupingState.get().groupOrder.length).toBeGreaterThan(
         0,
       );
       expect(
-        Object.keys(table.store.state.groupingState.groupValues).length,
+        Object.keys(table.atoms.groupingState.get().groupValues).length,
       ).toBeGreaterThan(0);
     });
   });
@@ -441,7 +441,7 @@ describe("useTableView - Extended Grouping", () => {
         table.setGrouping(["col2"]);
       });
 
-      const initialGroupOrder = table.store.state.groupingState.groupOrder;
+      const initialGroupOrder = table.atoms.groupingState.get().groupOrder;
 
       // Ensure we have at least 2 groups to test drag
       expect(initialGroupOrder.length).toBeGreaterThanOrEqual(2);
@@ -460,7 +460,7 @@ describe("useTableView - Extended Grouping", () => {
         } as DragEndEvent);
       });
 
-      const newGroupOrder = table.store.state.groupingState.groupOrder;
+      const newGroupOrder = table.atoms.groupingState.get().groupOrder;
 
       expect(newGroupOrder).toEqual([
         secondGroupId,
@@ -483,7 +483,7 @@ describe("useTableView - Extended Grouping", () => {
           properties: mockProperties,
         });
         act(() => table.setGrouping(["col2"]));
-        const previous = table.store.state.groupingState.groupOrder;
+        const previous = table.atoms.groupingState.get().groupOrder;
         const onGroupingStateChange = vi.fn();
         table.setOptions((options) => ({
           ...options,
@@ -502,7 +502,7 @@ describe("useTableView - Extended Grouping", () => {
         });
 
         expect(onGroupingStateChange).not.toHaveBeenCalled();
-        expect(table.store.state.groupingState.groupOrder).toEqual(previous);
+        expect(table.atoms.groupingState.get().groupOrder).toEqual(previous);
       },
     );
   });
@@ -523,14 +523,14 @@ describe("useTableView - Extended Grouping", () => {
       expect(groupedRow?.getIsGrouped()).toBe(true);
       const groupId = groupedRow!.id;
       const initialVisibility =
-        table.store.state.groupingState.groupVisibility[groupId] ?? true;
+        table.atoms.groupingState.get().groupVisibility[groupId] ?? true;
 
       act(() => {
         groupedRow!.toggleGroupVisibility();
       });
 
       const newVisibility =
-        table.store.state.groupingState.groupVisibility[groupId];
+        table.atoms.groupingState.get().groupVisibility[groupId];
       expect(newVisibility).toBe(!initialVisibility);
     });
   });

--- a/packages/table-hook/src/__tests__/resource-api.test.tsx
+++ b/packages/table-hook/src/__tests__/resource-api.test.tsx
@@ -16,7 +16,6 @@ import {
   type DataResourceAction,
   type PropertiesResourceAction,
   type ResourceChange,
-  type ResourceVersion,
   type ViewResourceAction,
 } from "@/table-contexts";
 import { useTableView } from "@/table-contexts/use-table-view";
@@ -34,31 +33,6 @@ function getLastResourceChange<TResource, TAction>(mock: MockWithLastCall) {
 }
 
 describe("useTableView resource API", () => {
-  it("ResourceVersion_IdentifiesTimestampedResourceSnapshots", () => {
-    const { result } = renderHook(() =>
-      useTableView({
-        plugins,
-        defaultData: mockData,
-        defaultProperties: mockProperties,
-      }),
-    );
-    const initialVersion: ResourceVersion = result.current.resourceVersion;
-
-    expect(initialVersion.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
-    );
-    expect(typeof initialVersion.ts).toBe("number");
-
-    act(() => {
-      result.current.table.addRow();
-    });
-
-    const nextVersion: ResourceVersion = result.current.resourceVersion;
-    expect(nextVersion.id).not.toBe(initialVersion.id);
-    expect(typeof nextVersion.ts).toBe("number");
-    expect(nextVersion.ts).toBeGreaterThanOrEqual(initialVersion.ts);
-  });
-
   it("ResourceActions_CallbacksReceiveCompleteReplacementEnvelope", () => {
     const onDataChange = vi.fn();
     const { result } = renderHook(() =>

--- a/packages/table-hook/src/__tests__/resource-api.test.tsx
+++ b/packages/table-hook/src/__tests__/resource-api.test.tsx
@@ -388,14 +388,14 @@ describe("useTableView resource API", () => {
       "col2",
       "col3",
     ]);
-    expect(result.current.table.store.state.columnOrder).toEqual([
+    expect(result.current.table.atoms.columnOrder.get()).toEqual([
       "col1",
       "col2",
     ]);
 
     rerender({ properties: nextProperties! });
 
-    expect(result.current.table.store.state.columnOrder).toEqual([
+    expect(result.current.table.atoms.columnOrder.get()).toEqual([
       "col1",
       "col2",
       "col3",
@@ -545,7 +545,7 @@ describe("useTableView resource API", () => {
     expect(result.current.table.getRowModel().rows).toHaveLength(
       mockData.length + 1,
     );
-    expect(result.current.table.store.state.columnOrder).toEqual([
+    expect(result.current.table.atoms.columnOrder.get()).toEqual([
       "col1",
       "col2",
     ]);
@@ -582,7 +582,7 @@ describe("useTableView resource API", () => {
     expect(result.current.table.getRowModel().rows).toHaveLength(
       mockData.length,
     );
-    expect(result.current.table.store.state.columnOrder).toEqual([
+    expect(result.current.table.atoms.columnOrder.get()).toEqual([
       "col1",
       "col2",
       "col3",
@@ -755,7 +755,7 @@ describe("useTableView resource API", () => {
         type: "text",
       });
     });
-    expect(result.current.table.store.state.columnOrder).toEqual([
+    expect(result.current.table.atoms.columnOrder.get()).toEqual([
       "col1",
       "col2",
       "col3",
@@ -803,7 +803,7 @@ describe("useTableView resource API", () => {
     act(() => {
       result.current.table.removeColumnInfo("col3");
     });
-    expect(result.current.table.store.state.columnOrder).toEqual([
+    expect(result.current.table.atoms.columnOrder.get()).toEqual([
       "col1",
       "col2",
     ]);

--- a/packages/table-hook/src/__tests__/row-actions.test.tsx
+++ b/packages/table-hook/src/__tests__/row-actions.test.tsx
@@ -734,11 +734,13 @@ describe("useTableView - Row Custom APIs", () => {
         table.setGrouping(["col2"]);
       });
 
-      const todoGroupId = table.store.state.groupingState.groupOrder.find(
-        (groupId) =>
-          table.store.state.groupingState.groupValues[groupId]?.value ===
-          "TODO",
-      );
+      const todoGroupId = table.atoms.groupingState
+        .get()
+        .groupOrder.find(
+          (groupId) =>
+            table.atoms.groupingState.get().groupValues[groupId]?.value ===
+            "TODO",
+        );
       expect(todoGroupId).toBeDefined();
 
       act(() => {
@@ -764,7 +766,7 @@ describe("useTableView - Row Custom APIs", () => {
 
       await waitFor(() => {
         const groupValues = Object.values(
-          table.store.state.groupingState.groupValues,
+          table.atoms.groupingState.get().groupValues,
         ).map((group) => group.value);
         expect(groupValues).toEqual(["DONE"]);
       });

--- a/packages/table-hook/src/__tests__/sorting-grouping.test.tsx
+++ b/packages/table-hook/src/__tests__/sorting-grouping.test.tsx
@@ -90,7 +90,7 @@ describe("useTableView - Sorting", () => {
       data: mockData,
       properties: mockProperties,
     });
-    const sorting = table.store.state.sorting;
+    const sorting = table.atoms.sorting.get();
 
     expect(sorting).toEqual([]);
   });
@@ -190,7 +190,7 @@ describe("useTableView - Sorting", () => {
       table.getColumn("col2")?.clearSorting();
     });
 
-    expect(table.store.state.sorting).toEqual([]);
+    expect(table.atoms.sorting.get()).toEqual([]);
   });
 
   it("should support multi-column sorting", () => {
@@ -225,13 +225,13 @@ describe("useTableView - Sorting", () => {
       table.setSorting([{ id: "col1", desc: false }]);
     });
 
-    expect(table.store.state.sorting).toHaveLength(1);
+    expect(table.atoms.sorting.get()).toHaveLength(1);
 
     act(() => {
       table.resetSorting();
     });
 
-    expect(table.store.state.sorting).toEqual([]);
+    expect(table.atoms.sorting.get()).toEqual([]);
   });
 });
 
@@ -241,7 +241,7 @@ describe("useTableView - Grouping", () => {
       data: mockData,
       properties: mockProperties,
     });
-    const grouping = table.store.state.grouping;
+    const grouping = table.atoms.grouping.get();
 
     expect(grouping).toEqual([]);
   });
@@ -260,7 +260,7 @@ describe("useTableView - Grouping", () => {
 
     // Should have group rows
     expect(groupedRows.length).toBeGreaterThan(0);
-    expect(table.store.state.grouping).toEqual(["col3"]);
+    expect(table.atoms.grouping.get()).toEqual(["col3"]);
   });
 
   it("should get grouped row values", () => {
@@ -293,12 +293,12 @@ describe("useTableView - Grouping", () => {
       table.setGrouping(["col3"]);
     });
 
-    expect(table.store.state.grouping).toEqual(["col3"]);
+    expect(table.atoms.grouping.get()).toEqual(["col3"]);
 
     act(() => {
       table.resetGrouping();
     });
 
-    expect(table.store.state.grouping).toEqual([]);
+    expect(table.atoms.grouping.get()).toEqual([]);
   });
 });

--- a/packages/table-hook/src/features/columns-info.ts
+++ b/packages/table-hook/src/features/columns-info.ts
@@ -156,7 +156,8 @@ export const ColumnsInfoFeature: TableFeature = {
     const instance = table as unknown as _TableInstance;
 
     const getColumnVisibilityFromInfo = () => {
-      const { columnOrder, columnsInfo } = instance.store.state;
+      const columnOrder = instance.atoms.columnOrder.get();
+      const columnsInfo = instance.atoms.columnsInfo.get();
       return columnOrder.reduce<Record<string, boolean>>((acc, colId) => {
         const info = columnsInfo[colId];
         acc[colId] = !info?.hidden && !info?.isDeleted;
@@ -216,7 +217,7 @@ export const ColumnsInfoFeature: TableFeature = {
 
     /** Column Getters */
     instance.getColumnInfo = (colId) => {
-      const info = instance.store.state.columnsInfo[colId];
+      const info = instance.atoms.columnsInfo.get()[colId];
       if (!info) {
         throw new Error(`[TableView] Column info not found: "${colId}"`);
       }
@@ -224,14 +225,15 @@ export const ColumnsInfoFeature: TableFeature = {
     };
     instance.getColumnPlugin = (colId) => {
       const type = instance.getColumnInfo(colId).type;
-      const plugin = instance.store.state.cellPlugins[type];
+      const plugin = instance.atoms.cellPlugins.get()[type];
       if (!plugin) {
         throw new Error(`[TableView] Plugin not found: ${type}`);
       }
       return plugin;
     };
     instance.getDeletedColumns = () => {
-      const { columnOrder, columnsInfo } = instance.store.state;
+      const columnOrder = instance.atoms.columnOrder.get();
+      const columnsInfo = instance.atoms.columnsInfo.get();
       return columnOrder.reduce<ColumnInfo[]>((acc, colId) => {
         const info = columnsInfo[colId];
         if (!info?.isDeleted) return acc;
@@ -240,7 +242,7 @@ export const ColumnsInfoFeature: TableFeature = {
       }, []);
     };
     instance.countVisibleColumns = () => {
-      const { columnsInfo } = instance.store.state;
+      const columnsInfo = instance.atoms.columnsInfo.get();
       return Object.values(columnsInfo).reduce((acc, info) => {
         if (!info.hidden && !info.isDeleted) acc++;
         return acc;
@@ -420,7 +422,8 @@ export const ColumnsInfoFeature: TableFeature = {
     };
     instance.addColumnInfo = (payload) => {
       const actionId = v4();
-      const { cellPlugins, columnsInfo } = instance.store.state;
+      const cellPlugins = instance.atoms.cellPlugins.get();
+      const columnsInfo = instance.atoms.columnsInfo.get();
       const { id, name, type, at } = payload;
       if (columnsInfo[id]) {
         throw new Error(`[TableView] Column already exists: "${id}"`);
@@ -467,7 +470,7 @@ export const ColumnsInfoFeature: TableFeature = {
     };
     instance.duplicateColumnInfo = (colId) => {
       const actionId = v4();
-      const { cellPlugins } = instance.store.state;
+      const cellPlugins = instance.atoms.cellPlugins.get();
       const src = instance.getColumnInfo(colId);
       const newColId = v4();
       const idsUpdater = createIdsUpdater(newColId, {
@@ -564,7 +567,7 @@ export const ColumnsInfoFeature: TableFeature = {
       colId: string,
       type: PluginType<TPlugins>,
     ) => {
-      const destPlugin = instance.store.state.cellPlugins[type] as
+      const destPlugin = instance.atoms.cellPlugins.get()[type] as
         | InferPlugin<TPlugins>
         | undefined;
       if (!destPlugin) {
@@ -622,14 +625,14 @@ export const ColumnsInfoFeature: TableFeature = {
     };
     /** Column name */
     instance.checkIsUniqueColumnName = (name) => {
-      return Object.values(instance.store.state.columnsInfo).every(
+      return Object.values(instance.atoms.columnsInfo.get()).every(
         (info) => info.name !== name,
       );
     };
     instance.generateUniqueColumnName = (initial = "") => {
       return getUniqueName(
         initial,
-        Object.values(instance.store.state.columnsInfo).map(
+        Object.values(instance.atoms.columnsInfo.get()).map(
           (info) => info.name,
         ),
       );

--- a/packages/table-hook/src/features/counting.ts
+++ b/packages/table-hook/src/features/counting.ts
@@ -61,7 +61,7 @@ export const CountingFeature: TableFeature = {
           `[TableView] Column counting is not enabled. To enable, pass \`enableColumnCounting: true\` to your table options.`,
         );
       }
-      const counting = instance.store.state.columnCounting;
+      const counting = instance.atoms.columnCounting.get();
       return counting[colId] ?? { method: CountMethod.NONE };
     };
     instance.getColumnCountResult = (colId) => {

--- a/packages/table-hook/src/features/extended-grouped-row-model.ts
+++ b/packages/table-hook/src/features/extended-grouped-row-model.ts
@@ -1,5 +1,6 @@
 import type { Row, RowData, RowModel, Table } from "@tanstack/react-table";
 import { constructRow, flattenBy, tableMemo } from "@tanstack/react-table";
+import { aggregateColumnValue } from "@tanstack/react-table/static-functions";
 
 import type { AnyRowData, AnyTableFeatures } from "@/features/types";
 import { createGroupId } from "@/features/utils";
@@ -153,23 +154,25 @@ export function getExtendedGroupedRowModel<TData extends RowData>(): (
                   return row._valuesCache[columnId];
                 }
 
-                if (Object.hasOwn(row._groupingValuesCache, columnId)) {
-                  return row._groupingValuesCache[columnId] as unknown;
+                if (
+                  Object.hasOwn(row._aggregationValuesCache ?? {}, columnId)
+                ) {
+                  return row._aggregationValuesCache?.[columnId];
                 }
 
-                // Aggregate the values
                 const column = table.getColumn(columnId);
-                const aggregateFn = column?.getAggregationFn();
+                if (typeof column?.getAggregationFns !== "function") return;
 
-                if (aggregateFn) {
-                  row._groupingValuesCache[columnId] = aggregateFn(
-                    columnId,
-                    leafRows,
-                    groupedRows,
-                  ) as unknown;
+                const cache = (row._aggregationValuesCache ??= {});
+                cache[columnId] = aggregateColumnValue({
+                  subRows,
+                  column,
+                  groupingRow: row,
+                  rows: groupedRows,
+                  uniqueRows: true,
+                });
 
-                  return row._groupingValuesCache[columnId] as unknown;
-                }
+                return cache[columnId];
               },
             });
 

--- a/packages/table-hook/src/features/freezing.ts
+++ b/packages/table-hook/src/features/freezing.ts
@@ -48,18 +48,19 @@ export const FreezingFeature: TableFeature = {
     };
     const normalizeFreezingState = (state: FreezingState): FreezingState => {
       if (!state) return null;
-      const index = instance.store.state.columnOrder.indexOf(state.colId);
+      const index = instance.atoms.columnOrder.get().indexOf(state.colId);
       return index < 0 ? null : { colId: state.colId, index };
     };
 
     instance.getFreezingState = () => {
       throwIfDisabled();
-      return normalizeFreezingState(instance.store.state.columnFreezing);
+      return normalizeFreezingState(instance.atoms.columnFreezing.get());
     };
     instance.getCanFreezeColumn = (colId) => {
       throwIfDisabled();
-      const index = instance.store.state.columnOrder.indexOf(colId);
-      return index >= 0 && index < instance.store.state.columnOrder.length - 1;
+      const columnOrder = instance.atoms.columnOrder.get();
+      const index = columnOrder.indexOf(colId);
+      return index >= 0 && index < columnOrder.length - 1;
     };
     instance.setColumnFreezing = (updater) => {
       const nextState = functionalUpdate(updater, instance.getFreezingState());
@@ -67,9 +68,9 @@ export const FreezingFeature: TableFeature = {
       instance.options.onColumnFreezingChange?.(normalizedState);
       instance.setColumnPinning({
         start: normalizedState
-          ? instance.store.state.columnOrder.slice(0, normalizedState.index + 1)
+          ? instance.atoms.columnOrder.get().slice(0, normalizedState.index + 1)
           : [],
-        end: instance.store.state.columnPinning.end,
+        end: instance.atoms.columnPinning.get().end,
       });
     };
     instance.toggleColumnFreezed = (colId) => {

--- a/packages/table-hook/src/features/grouping.ts
+++ b/packages/table-hook/src/features/grouping.ts
@@ -177,13 +177,13 @@ export const ExtendedGroupingFeature: TableFeature = {
     };
 
     table.getGroupedColumnInfo = () => {
-      const { grouping } = table.store.state;
+      const grouping = table.atoms.grouping.get();
       const groupedColumnId = grouping[0];
       if (!groupedColumnId) return null;
       return table.getColumnInfo(groupedColumnId);
     };
     table.getIsSomeGroupVisible = () => {
-      const { groupOrder, groupVisibility } = table.store.state.groupingState;
+      const { groupOrder, groupVisibility } = table.atoms.groupingState.get();
       return groupOrder.some((groupId) => groupVisibility[groupId] ?? true);
     };
     table._setGroupingState = (updater) => {
@@ -269,7 +269,7 @@ export const ExtendedGroupingFeature: TableFeature = {
     };
     table.getGroupingValueRenderer = (groupId) => {
       return function Renderer(props) {
-        const { groupValues } = table.store.state.groupingState;
+        const { groupValues } = table.atoms.groupingState.get();
         const info = table.getGroupedColumnInfo();
         if (!info) {
           console.error(
@@ -304,7 +304,7 @@ export const ExtendedGroupingFeature: TableFeature = {
     const table = _table as unknown as _TableInstance;
 
     prototype.getShouldShowGroupAggregates = function () {
-      return table.store.state.groupingState.showAggregates;
+      return table.atoms.groupingState.get().showAggregates;
     };
     prototype.toggleGroupAggregates = function () {
       table._setGroupingState((v) => ({

--- a/packages/table-hook/src/features/index.ts
+++ b/packages/table-hook/src/features/index.ts
@@ -12,6 +12,7 @@ import {
   rowExpandingFeature,
   rowSortingFeature,
   tableFeatures,
+  type TableFeatures as BaseTableFeatures,
   type RowData,
 } from "@tanstack/react-table";
 
@@ -132,19 +133,7 @@ export * from "@/features/row-actions";
 export * from "@/features/constants";
 export * from "@/features/types";
 
-export interface TableFeatures {
-  columnGroupingFeature: typeof columnGroupingFeature;
-  columnOrderingFeature: typeof columnOrderingFeature;
-  columnPinningFeature: typeof columnPinningFeature;
-  columnResizingFeature: typeof columnResizingFeature;
-  columnSizingFeature: typeof columnSizingFeature;
-  columnVisibilityFeature: typeof columnVisibilityFeature;
-  rowExpandingFeature: typeof rowExpandingFeature;
-  rowAggregationFeature: typeof rowAggregationFeature;
-  rowSortingFeature: typeof rowSortingFeature;
-  sortedRowModel: ReturnType<typeof createSortedRowModel>;
-  groupedRowModel: ReturnType<typeof getExtendedGroupedRowModel>;
-  expandedRowModel: ReturnType<typeof createExpandedRowModel>;
+export interface TableFeatures extends BaseTableFeatures {
   columnsInfoFeature: typeof ColumnsInfoFeature;
   countingFeature: typeof CountingFeature;
   freezingFeature: typeof FreezingFeature;

--- a/packages/table-hook/src/features/index.ts
+++ b/packages/table-hook/src/features/index.ts
@@ -8,6 +8,7 @@ import {
   columnVisibilityFeature,
   createExpandedRowModel,
   createSortedRowModel,
+  rowAggregationFeature,
   rowExpandingFeature,
   rowSortingFeature,
   tableFeatures,
@@ -139,6 +140,7 @@ export interface TableFeatures {
   columnSizingFeature: typeof columnSizingFeature;
   columnVisibilityFeature: typeof columnVisibilityFeature;
   rowExpandingFeature: typeof rowExpandingFeature;
+  rowAggregationFeature: typeof rowAggregationFeature;
   rowSortingFeature: typeof rowSortingFeature;
   sortedRowModel: ReturnType<typeof createSortedRowModel>;
   groupedRowModel: ReturnType<typeof getExtendedGroupedRowModel>;
@@ -159,6 +161,7 @@ export const DEFAULT_FEATURES = tableFeatures({
   columnSizingFeature,
   columnVisibilityFeature,
   rowExpandingFeature,
+  rowAggregationFeature,
   rowSortingFeature,
   sortedRowModel: createSortedRowModel(),
   groupedRowModel: getExtendedGroupedRowModel(),

--- a/packages/table-hook/src/features/menu.ts
+++ b/packages/table-hook/src/features/menu.ts
@@ -112,11 +112,11 @@ export const TableMenuFeature: TableFeature = {
 
     instance.getRowUrl = (rowId: string) =>
       instance.options.getRowUrl?.(rowId) ?? "";
-    instance.getTableMenuState = () => instance.store.state.menu;
+    instance.getTableMenuState = () => instance.atoms.menu.get();
     instance.setTableMenuState = (menu) => {
       instance.options.onTableMenuChange?.(menu);
     };
-    instance.getTableGlobalState = () => instance.store.state.tableGlobal;
+    instance.getTableGlobalState = () => instance.atoms.tableGlobal.get();
     instance.setTableGlobalState = (updater, action) => {
       instance.options.onTableGlobalChange?.(updater, action);
     };

--- a/packages/table-hook/src/features/row-actions.ts
+++ b/packages/table-hook/src/features/row-actions.ts
@@ -164,7 +164,7 @@ export const RowActionsFeature: TableFeature = {
     let kanbanDragSnapshot: Row[] | null = null;
 
     const scheduleGroupingStateSync = (rows: Row[]) => {
-      if (table.store.state.grouping.length > 0) {
+      if (table.atoms.grouping.get().length > 0) {
         queueMicrotask(() => {
           table._syncGroupingStateFromData(rows);
         });
@@ -184,7 +184,7 @@ export const RowActionsFeature: TableFeature = {
       return cell;
     };
     table.getTitleCell = (rowId) => {
-      const { columnOrder } = table.store.state;
+      const columnOrder = table.atoms.columnOrder.get();
       const cells = table.getRow(rowId).original.properties;
       for (const colId of columnOrder) {
         const plugin = table.getColumnPlugin(colId);
@@ -251,7 +251,7 @@ export const RowActionsFeature: TableFeature = {
             createdAt: now,
             lastEditedAt: now,
           };
-          table.store.state.columnOrder.forEach((colId) => {
+          table.atoms.columnOrder.get().forEach((colId) => {
             const plugin = table.getColumnPlugin(colId);
             row.properties[colId] = getDefaultCell(plugin);
           });
@@ -346,7 +346,8 @@ export const RowActionsFeature: TableFeature = {
     table.handleKanbanRowDragOver = (event) => {
       if ("canceled" in event && event.canceled) return;
 
-      const { grouping, groupingState } = table.store.state;
+      const grouping = table.atoms.grouping.get();
+      const groupingState = table.atoms.groupingState.get();
       const groupingColumnId = grouping[0];
       if (!groupingColumnId) return;
 
@@ -411,7 +412,8 @@ export const RowActionsFeature: TableFeature = {
       }
       kanbanDragSnapshot = null;
 
-      const { grouping, groupingState } = table.store.state;
+      const grouping = table.atoms.grouping.get();
+      const groupingState = table.atoms.groupingState.get();
       const groupingColumnId = grouping[0];
       const { source, target } = event.operation;
       const sourceGroupId = getKanbanColumnTargetId(source?.data);
@@ -467,9 +469,9 @@ export const RowActionsFeature: TableFeature = {
       );
     };
     table.updateRowIcon = (id, icon) => {
-      const colId = table.store.state.columnOrder.find(
-        (propId) => table.getColumnPlugin(propId).id === "title",
-      );
+      const colId = table.atoms.columnOrder
+        .get()
+        .find((propId) => table.getColumnPlugin(propId).id === "title");
       if (!colId) return;
       const actionId = v4();
       table.setTableData(
@@ -499,7 +501,9 @@ export const RowActionsFeature: TableFeature = {
     };
     // With Grouping API
     table.addRowToGroup = (groupId) => {
-      const { columnOrder, grouping, groupingState } = table.store.state;
+      const columnOrder = table.atoms.columnOrder.get();
+      const grouping = table.atoms.grouping.get();
+      const groupingState = table.atoms.groupingState.get();
       const rowId = v4();
       const actionId = v4();
       table.setTableData(

--- a/packages/table-hook/src/table-contexts/types.ts
+++ b/packages/table-hook/src/table-contexts/types.ts
@@ -11,11 +11,6 @@ import type {
   ViewResourceAction,
 } from "@/table-contexts/actions";
 
-export interface ResourceVersion {
-  id: string;
-  ts: number;
-}
-
 export interface TableState<TPlugins extends CellPlugin[]> {
   properties: ColumnDefs<TPlugins>;
   data: RowModel<TPlugins>[];

--- a/packages/table-hook/src/table-contexts/use-table-view.tsx
+++ b/packages/table-hook/src/table-contexts/use-table-view.tsx
@@ -86,13 +86,6 @@ function useResourceState<TResource, TAction>({
   const lastResourceRef = useRef(resource);
   const pendingResourceRef = useRef(resource);
 
-  useEffect(() => {
-    if (lastResourceRef.current !== resource) {
-      lastResourceRef.current = resource;
-      pendingResourceRef.current = resource;
-    }
-  }, [resource]);
-
   const setResource = useCallback<ResourceChangeFn<TResource, TAction>>(
     (updater, action) => {
       if (lastResourceRef.current !== resource) {

--- a/packages/table-hook/src/table-contexts/use-table-view.tsx
+++ b/packages/table-hook/src/table-contexts/use-table-view.tsx
@@ -4,7 +4,6 @@ import {
   useTable,
   type ColumnDef,
 } from "@tanstack/react-table";
-import { v4 } from "uuid";
 
 import { DEFAULT_FEATURES, type TableFeatures } from "@/features";
 import type { TableViewState } from "@/features/menu";
@@ -21,11 +20,7 @@ import type {
   ViewResourceAction,
 } from "@/table-contexts/actions";
 import { defaultColumn } from "@/table-contexts/column";
-import type {
-  BaseTableProps,
-  ResourceVersion,
-  TableState,
-} from "@/table-contexts/types";
+import type { BaseTableProps, TableState } from "@/table-contexts/types";
 import {
   createInitialTable,
   getMinWidth,
@@ -277,17 +272,5 @@ export function useTableView<TPlugins extends CellPlugin[]>(
     () => null,
   );
 
-  const resourceVersion = useMemo<ResourceVersion>(
-    () => ({ id: v4(), ts: Date.now() }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- This token must change whenever a controlled resource changes, even though the values are intentionally not exposed.
-    [dataEntity, propertiesResource, tableGlobalState],
-  );
-
-  return useMemo(
-    () => ({
-      table,
-      resourceVersion,
-    }),
-    [resourceVersion, table],
-  );
+  return useMemo(() => ({ table }), [table]);
 }

--- a/packages/table-view/package.json
+++ b/packages/table-view/package.json
@@ -48,7 +48,8 @@
     "@notion-kit/table-hook": "workspace:*",
     "@notion-kit/ui": "workspace:*",
     "@notion-kit/utils": "workspace:*",
-    "@tanstack/react-table": "v9.0.0-beta.38",
+    "@tanstack/react-store": "0.11.0",
+    "@tanstack/react-table": "v9.0.0-beta.58",
     "react-hotkeys-hook": "catalog:ui",
     "uuid": "catalog:uuid"
   },

--- a/packages/table-view/package.json
+++ b/packages/table-view/package.json
@@ -51,7 +51,8 @@
     "@tanstack/react-store": "0.11.0",
     "@tanstack/react-table": "v9.0.0-beta.58",
     "react-hotkeys-hook": "catalog:ui",
-    "uuid": "catalog:uuid"
+    "uuid": "catalog:uuid",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@notion-kit/config": "workspace:*",

--- a/packages/table-view/package.json
+++ b/packages/table-view/package.json
@@ -48,7 +48,6 @@
     "@notion-kit/table-hook": "workspace:*",
     "@notion-kit/ui": "workspace:*",
     "@notion-kit/utils": "workspace:*",
-    "@tanstack/react-store": "0.11.0",
     "@tanstack/react-table": "v9.0.0-beta.58",
     "react-hotkeys-hook": "catalog:ui",
     "uuid": "catalog:uuid",

--- a/packages/table-view/src/board-view/board-view-content.tsx
+++ b/packages/table-view/src/board-view/board-view-content.tsx
@@ -1,5 +1,9 @@
 import { Icon } from "@notion-kit/icons";
-import { TableViewMenuPage, type RowInstance } from "@notion-kit/table-hook";
+import {
+  TableViewMenuPage,
+  type RowInstance,
+  type TableInstance,
+} from "@notion-kit/table-hook";
 import { Kanban } from "@notion-kit/ui/kanban";
 import { Button } from "@notion-kit/ui/primitives";
 
@@ -41,12 +45,8 @@ function BoardViewContentInner({
   groupingState,
 }: {
   locked: boolean;
-  grouping: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["grouping"];
-  groupingState: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["groupingState"];
+  grouping: ReturnType<TableInstance["atoms"]["grouping"]["get"]>;
+  groupingState: ReturnType<TableInstance["atoms"]["groupingState"]["get"]>;
 }) {
   const { table } = useTableViewCtx();
   const handlers = useBoardDnd();

--- a/packages/table-view/src/common/group-actions.tsx
+++ b/packages/table-view/src/common/group-actions.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useStore } from "@tanstack/react-store";
 
 import { cn } from "@notion-kit/cn";
 import { Icon } from "@notion-kit/icons";
@@ -24,7 +25,7 @@ interface GroupActionsProps {
 
 export function GroupActions({ className, row }: GroupActionsProps) {
   const { table } = useTableViewCtx();
-  const { locked } = table.store.state.tableGlobal;
+  const { locked } = useStore(table.atoms.tableGlobal, (state) => state);
 
   const addRow = () => table.addRowToGroup(row.id);
 

--- a/packages/table-view/src/common/group-actions.tsx
+++ b/packages/table-view/src/common/group-actions.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useStore } from "@tanstack/react-store";
 
 import { cn } from "@notion-kit/cn";
 import { Icon } from "@notion-kit/icons";
@@ -25,8 +24,18 @@ interface GroupActionsProps {
 
 export function GroupActions({ className, row }: GroupActionsProps) {
   const { table } = useTableViewCtx();
-  const { locked } = useStore(table.atoms.tableGlobal, (state) => state);
 
+  return (
+    <table.Subscribe selector={(state) => state.tableGlobal.locked}>
+      {(locked) =>
+        locked ? null : <GroupActionsContent className={className} row={row} />
+      }
+    </table.Subscribe>
+  );
+}
+
+function GroupActionsContent({ className, row }: GroupActionsProps) {
+  const { table } = useTableViewCtx();
   const addRow = () => table.addRowToGroup(row.id);
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -36,7 +45,6 @@ export function GroupActions({ className, row }: GroupActionsProps) {
     setShowDeleteConfirm(false);
   };
 
-  if (locked) return null;
   return (
     <div
       className={cn(

--- a/packages/table-view/src/list-view/list-view-content.tsx
+++ b/packages/table-view/src/list-view/list-view-content.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import type { DragEndEvent } from "@dnd-kit/react";
 
 import { Icon } from "@notion-kit/icons";
+import type { TableInstance } from "@notion-kit/table-hook";
 import { AlertModal } from "@notion-kit/ui/alert-modal";
 import { Button, Dialog, Sortable } from "@notion-kit/ui/primitives";
 
@@ -45,9 +46,7 @@ export function ListViewContent() {
 
 interface ListViewContentInnerProps {
   locked: boolean;
-  sorting: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["sorting"];
+  sorting: ReturnType<TableInstance["atoms"]["sorting"]["get"]>;
   dialogOpen: boolean;
   setDialogOpen: (open: boolean) => void;
   pendingDragEndEvent: DragEndEvent | null;

--- a/packages/table-view/src/list-view/list-view-content.tsx
+++ b/packages/table-view/src/list-view/list-view-content.tsx
@@ -12,7 +12,6 @@ import { useTableViewCtx } from "@/table-contexts";
 import { ListRow } from "./list-row";
 
 export function ListViewContent() {
-  const [dialogOpen, setDialogOpen] = useState(false);
   const [pendingDragEndEvent, setPendingDragEndEvent] =
     useState<DragEndEvent | null>(null);
   const { table } = useTableViewCtx();
@@ -34,8 +33,6 @@ export function ListViewContent() {
         <ListViewContentInner
           locked={locked ?? false}
           sorting={sorting}
-          dialogOpen={dialogOpen}
-          setDialogOpen={setDialogOpen}
           pendingDragEndEvent={pendingDragEndEvent}
           setPendingDragEndEvent={setPendingDragEndEvent}
         />
@@ -47,8 +44,6 @@ export function ListViewContent() {
 interface ListViewContentInnerProps {
   locked: boolean;
   sorting: ReturnType<TableInstance["atoms"]["sorting"]["get"]>;
-  dialogOpen: boolean;
-  setDialogOpen: (open: boolean) => void;
   pendingDragEndEvent: DragEndEvent | null;
   setPendingDragEndEvent: (event: DragEndEvent | null) => void;
 }
@@ -56,8 +51,6 @@ interface ListViewContentInnerProps {
 function ListViewContentInner({
   locked,
   sorting,
-  dialogOpen,
-  setDialogOpen,
   pendingDragEndEvent,
   setPendingDragEndEvent,
 }: ListViewContentInnerProps) {
@@ -70,18 +63,16 @@ function ListViewContentInner({
       const isSorted = sorting.length > 0;
       if (!isSorted) return table.handleRowDragEnd(e);
       setPendingDragEndEvent(e);
-      setDialogOpen(true);
     },
-    [setDialogOpen, setPendingDragEndEvent, sorting.length, table],
+    [setPendingDragEndEvent, sorting.length, table],
   );
 
   const handleConfirmRemoveSorting = () => {
     if (pendingDragEndEvent) {
       table.resetSorting();
       table.handleRowDragEnd(pendingDragEndEvent);
-      setPendingDragEndEvent(null);
     }
-    setDialogOpen(false);
+    setPendingDragEndEvent(null);
   };
 
   return (
@@ -113,7 +104,12 @@ function ListViewContentInner({
           </Button>
         )}
       </div>
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <Dialog
+        open={pendingDragEndEvent !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDragEndEvent(null);
+        }}
+      >
         <AlertModal
           title="Would you like to remove sorting?"
           primary="Remove"

--- a/packages/table-view/src/menus/edit-group-menu.tsx
+++ b/packages/table-view/src/menus/edit-group-menu.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useStore } from "@tanstack/react-store";
 import { flexRender } from "@tanstack/react-table";
 
 import { useIsClient } from "@notion-kit/hooks";
@@ -24,11 +23,6 @@ export function EditGroupMenu() {
   const isClient = useIsClient();
   const { table } = useTableViewCtx();
 
-  const { layout } = useStore(table.atoms.tableGlobal, (state) => state);
-  const { groupOrder, groupVisibility, hideEmptyGroups } = useStore(
-    table.atoms.groupingState,
-    (state) => state,
-  );
   const col = table.getGroupedColumnInfo();
 
   return (
@@ -51,12 +45,18 @@ export function EditGroupMenu() {
           <MenuItemSelect>{col?.name ?? ""}</MenuItemSelect>
         </DropdownMenuItem>
         {/* TODO Sort group by */}
-        <DropdownMenuCheckboxItem
-          closeOnClick={false}
-          label="Hide empty groups"
-          checked={hideEmptyGroups}
-          onCheckedChange={table.toggleHideEmptyGroups}
-        />
+        <table.Subscribe
+          selector={(state) => state.groupingState.hideEmptyGroups}
+        >
+          {(hideEmptyGroups) => (
+            <DropdownMenuCheckboxItem
+              closeOnClick={false}
+              label="Hide empty groups"
+              checked={hideEmptyGroups}
+              onCheckedChange={table.toggleHideEmptyGroups}
+            />
+          )}
+        </table.Subscribe>
       </DropdownMenuGroup>
       <DropdownMenuSeparator />
       <DropdownMenuGroup>
@@ -72,34 +72,49 @@ export function EditGroupMenu() {
             </Button>
           </div>
         </DropdownMenuLabel>
-        <Sortable.Root onDragEnd={table.handleGroupedRowDragEnd}>
-          <Sortable.List>
-            {groupOrder.map((groupId, index) => {
-              const renderer = table.getGroupingValueRenderer(groupId);
-              return (
-                <GroupItem
-                  key={groupId}
-                  id={groupId}
-                  index={index}
-                  visible={groupVisibility[groupId] ?? true}
-                  onVisibilityChange={() => table.toggleGroupVisible(groupId)}
-                >
-                  {flexRender(renderer, {})}
-                </GroupItem>
-              );
-            })}
-          </Sortable.List>
-        </Sortable.Root>
+        <table.Subscribe
+          selector={(state) => ({
+            groupOrder: state.groupingState.groupOrder,
+            groupVisibility: state.groupingState.groupVisibility,
+          })}
+        >
+          {({ groupOrder, groupVisibility }) => (
+            <Sortable.Root onDragEnd={table.handleGroupedRowDragEnd}>
+              <Sortable.List>
+                {groupOrder.map((groupId, index) => {
+                  const renderer = table.getGroupingValueRenderer(groupId);
+                  return (
+                    <GroupItem
+                      key={groupId}
+                      id={groupId}
+                      index={index}
+                      visible={groupVisibility[groupId] ?? true}
+                      onVisibilityChange={() =>
+                        table.toggleGroupVisible(groupId)
+                      }
+                    >
+                      {flexRender(renderer, {})}
+                    </GroupItem>
+                  );
+                })}
+              </Sortable.List>
+            </Sortable.Root>
+          )}
+        </table.Subscribe>
       </DropdownMenuGroup>
       <DropdownMenuSeparator />
       <DropdownMenuGroup>
-        {layout !== "board" && (
-          <DropdownMenuItem
-            icon={<Icon.Trash />}
-            label="Remove grouping"
-            onClick={() => table.setGroupingColumn(null)}
-          />
-        )}
+        <table.Subscribe selector={(state) => state.tableGlobal.layout}>
+          {(layout) =>
+            layout !== "board" && (
+              <DropdownMenuItem
+                icon={<Icon.Trash />}
+                label="Remove grouping"
+                onClick={() => table.setGroupingColumn(null)}
+              />
+            )
+          }
+        </table.Subscribe>
         <DropdownMenuItem
           icon={<Icon.QuestionMarkCircled />}
           label="Learn about grouping"

--- a/packages/table-view/src/menus/edit-group-menu.tsx
+++ b/packages/table-view/src/menus/edit-group-menu.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useStore } from "@tanstack/react-store";
 import { flexRender } from "@tanstack/react-table";
 
 import { useIsClient } from "@notion-kit/hooks";
@@ -23,9 +24,11 @@ export function EditGroupMenu() {
   const isClient = useIsClient();
   const { table } = useTableViewCtx();
 
-  const { layout } = table.getTableGlobalState();
-  const { groupOrder, groupVisibility, hideEmptyGroups } =
-    table.store.state.groupingState;
+  const { layout } = useStore(table.atoms.tableGlobal, (state) => state);
+  const { groupOrder, groupVisibility, hideEmptyGroups } = useStore(
+    table.atoms.groupingState,
+    (state) => state,
+  );
   const col = table.getGroupedColumnInfo();
 
   return (

--- a/packages/table-view/src/menus/layout-menu.tsx
+++ b/packages/table-view/src/menus/layout-menu.tsx
@@ -5,6 +5,7 @@ import {
   LAYOUT_OPTIONS,
   ROW_VIEW_OPTIONS,
   RowViewType,
+  type TableInstance,
 } from "@notion-kit/table-hook";
 import {
   Button,
@@ -33,8 +34,8 @@ function LayoutMenuContent({
   currentLayout,
 }: {
   currentLayout: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["tableGlobal"]["layout"];
+    TableInstance["atoms"]["tableGlobal"]["get"]
+  >["layout"];
 }) {
   const { table } = useTableViewCtx();
 

--- a/packages/table-view/src/menus/props-menu.tsx
+++ b/packages/table-view/src/menus/props-menu.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useStore } from "@tanstack/react-store";
 
 import { cn } from "@notion-kit/cn";
 import { Icon } from "@notion-kit/icons";
@@ -31,13 +32,19 @@ import { useTableViewCtx } from "@/table-contexts";
  */
 export function PropsMenu() {
   const { table } = useTableViewCtx();
-  const { columnOrder } = table.store.state;
-  const noShownProps = table.countVisibleColumns() === 1;
+  const columnOrder = useStore(table.atoms.columnOrder, (state) => state);
+  const columnsInfo = useStore(table.atoms.columnsInfo, (state) => state);
+  const columnVisibility = useStore(
+    table.atoms.columnVisibility,
+    (state) => state,
+  );
+  const noShownProps =
+    Object.values(columnVisibility).filter(Boolean).length === 1;
 
   const [search, setSearch] = useState("");
   const { props, deletedCount } = columnOrder.reduce(
     (acc, propId) => {
-      const info = table.getColumnInfo(propId);
+      const info = columnsInfo[propId]!;
       if (!info.isDeleted) {
         acc.props.push({ ...info, id: propId });
       } else {

--- a/packages/table-view/src/menus/props-menu.tsx
+++ b/packages/table-view/src/menus/props-menu.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useStore } from "@tanstack/react-store";
 
 import { cn } from "@notion-kit/cn";
 import { Icon } from "@notion-kit/icons";
@@ -32,30 +31,8 @@ import { useTableViewCtx } from "@/table-contexts";
  */
 export function PropsMenu() {
   const { table } = useTableViewCtx();
-  const columnOrder = useStore(table.atoms.columnOrder, (state) => state);
-  const columnsInfo = useStore(table.atoms.columnsInfo, (state) => state);
-  const columnVisibility = useStore(
-    table.atoms.columnVisibility,
-    (state) => state,
-  );
-  const noShownProps =
-    Object.values(columnVisibility).filter(Boolean).length === 1;
-
   const [search, setSearch] = useState("");
-  const { props, deletedCount } = columnOrder.reduce(
-    (acc, propId) => {
-      const info = columnsInfo[propId]!;
-      if (!info.isDeleted) {
-        acc.props.push({ ...info, id: propId });
-      } else {
-        acc.deletedCount++;
-      }
-      return acc;
-    },
-    { deletedCount: 0, props: [] as ColumnInfo[] },
-  );
 
-  // Menu actions
   const openEditPropMenu = (propId: string) =>
     table.setTableMenuState({
       open: true,
@@ -64,104 +41,135 @@ export function PropsMenu() {
     });
 
   return (
-    <>
-      <MenuHeader
-        title="Properties"
-        onBack={() => table.setTableMenuState({ open: true, page: null })}
-      />
-      <Autocomplete
-        items={props}
-        itemToStringValue={(prop) => prop.name}
-        value={search}
-        onValueChange={setSearch}
-        open
-        autoHighlight="always"
-        openOnInputClick
-      >
-        <AutocompleteInput
-          clear
-          onCancel={() => setSearch("")}
-          onKeyDown={(e) => e.stopPropagation()}
-          placeholder="Search for a property..."
-        />
-        <AutocompleteContent variant="inline">
-          <AutocompleteList>
-            <AutocompleteGroup>
-              <MenuGroupHeader
-                title="Properties"
-                action={search ? null : noShownProps ? "Show all" : "Hide all"}
-                onActionClick={table.toggleAllColumnsVisible}
-              />
-              <Sortable.Root
-                disabled={search.length > 0}
-                onDragEnd={table.handleColumnDragEnd}
-              >
-                <Sortable.List>
-                  <AutocompleteCollection>
-                    {(prop: ColumnInfo) => (
-                      <PropertyItem
-                        key={prop.id}
-                        index={props.findIndex((item) => item.id === prop.id)}
-                        draggable={search.length === 0}
-                        info={prop}
-                        onClick={() => openEditPropMenu(prop.id)}
-                        onVisibilityChange={() =>
-                          table.setColumnInfo(prop.id, {
-                            hidden: !prop.hidden,
-                          })
-                        }
-                      />
-                    )}
-                  </AutocompleteCollection>
-                </Sortable.List>
-              </Sortable.Root>
-            </AutocompleteGroup>
-          </AutocompleteList>
-          <AutocompleteEmpty className="px-3 text-start text-muted">
-            No results
-          </AutocompleteEmpty>
-        </AutocompleteContent>
-      </Autocomplete>
-      <DropdownMenuSeparator />
-      <DropdownMenuGroup>
-        <DropdownMenuItem
-          variant="secondary"
-          icon={<Icon.Plus className="size-4" />}
-          label="New property"
-          closeOnClick={false}
-          onClick={() =>
-            table.setTableMenuState({
-              open: true,
-              page: TableViewMenuPage.CreateProp,
-            })
-          }
-        />
-        {deletedCount > 0 && (
-          <DropdownMenuItem
-            variant="secondary"
-            icon={<Icon.Trash />}
-            label="Deleted properties"
-            closeOnClick={false}
-            onClick={() =>
-              table.setTableMenuState({
-                open: true,
-                page: TableViewMenuPage.DeletedProps,
-              })
+    <table.Subscribe
+      selector={(state) => ({
+        columnOrder: state.columnOrder,
+        columnsInfo: state.columnsInfo,
+        columnVisibility: state.columnVisibility,
+      })}
+    >
+      {({ columnOrder, columnsInfo, columnVisibility }) => {
+        const noShownProps =
+          Object.values(columnVisibility).filter(Boolean).length === 1;
+        const { props, deletedCount } = columnOrder.reduce(
+          (acc, propId) => {
+            const info = columnsInfo[propId]!;
+            if (!info.isDeleted) {
+              acc.props.push({ ...info, id: propId });
+            } else {
+              acc.deletedCount++;
             }
-          >
-            <MenuItemSelect>{deletedCount}</MenuItemSelect>
-          </DropdownMenuItem>
-        )}
-        <DropdownMenuItem
-          variant="secondary"
-          onClick={() =>
-            window.open("https://www.notion.com/help/database-properties")
-          }
-          icon={<Icon.Help className="size-4" />}
-          label="Learn about properties"
-        />
-      </DropdownMenuGroup>
-    </>
+            return acc;
+          },
+          { deletedCount: 0, props: [] as ColumnInfo[] },
+        );
+
+        return (
+          <>
+            <MenuHeader
+              title="Properties"
+              onBack={() => table.setTableMenuState({ open: true, page: null })}
+            />
+            <Autocomplete
+              items={props}
+              itemToStringValue={(prop) => prop.name}
+              value={search}
+              onValueChange={setSearch}
+              open
+              autoHighlight="always"
+              openOnInputClick
+            >
+              <AutocompleteInput
+                clear
+                onCancel={() => setSearch("")}
+                onKeyDown={(e) => e.stopPropagation()}
+                placeholder="Search for a property..."
+              />
+              <AutocompleteContent variant="inline">
+                <AutocompleteList>
+                  <AutocompleteGroup>
+                    <MenuGroupHeader
+                      title="Properties"
+                      action={
+                        search ? null : noShownProps ? "Show all" : "Hide all"
+                      }
+                      onActionClick={table.toggleAllColumnsVisible}
+                    />
+                    <Sortable.Root
+                      disabled={search.length > 0}
+                      onDragEnd={table.handleColumnDragEnd}
+                    >
+                      <Sortable.List>
+                        <AutocompleteCollection>
+                          {(prop: ColumnInfo) => (
+                            <PropertyItem
+                              key={prop.id}
+                              index={props.findIndex(
+                                (item) => item.id === prop.id,
+                              )}
+                              draggable={search.length === 0}
+                              info={prop}
+                              onClick={() => openEditPropMenu(prop.id)}
+                              onVisibilityChange={() =>
+                                table.setColumnInfo(prop.id, {
+                                  hidden: !prop.hidden,
+                                })
+                              }
+                            />
+                          )}
+                        </AutocompleteCollection>
+                      </Sortable.List>
+                    </Sortable.Root>
+                  </AutocompleteGroup>
+                </AutocompleteList>
+                <AutocompleteEmpty className="px-3 text-start text-muted">
+                  No results
+                </AutocompleteEmpty>
+              </AutocompleteContent>
+            </Autocomplete>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem
+                variant="secondary"
+                icon={<Icon.Plus className="size-4" />}
+                label="New property"
+                closeOnClick={false}
+                onClick={() =>
+                  table.setTableMenuState({
+                    open: true,
+                    page: TableViewMenuPage.CreateProp,
+                  })
+                }
+              />
+              {deletedCount > 0 && (
+                <DropdownMenuItem
+                  variant="secondary"
+                  icon={<Icon.Trash />}
+                  label="Deleted properties"
+                  closeOnClick={false}
+                  onClick={() =>
+                    table.setTableMenuState({
+                      open: true,
+                      page: TableViewMenuPage.DeletedProps,
+                    })
+                  }
+                >
+                  <MenuItemSelect>{deletedCount}</MenuItemSelect>
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem
+                variant="secondary"
+                onClick={() =>
+                  window.open("https://www.notion.com/help/database-properties")
+                }
+                icon={<Icon.Help className="size-4" />}
+                label="Learn about properties"
+              />
+            </DropdownMenuGroup>
+          </>
+        );
+      }}
+    </table.Subscribe>
   );
 }
 

--- a/packages/table-view/src/menus/select-group-menu.tsx
+++ b/packages/table-view/src/menus/select-group-menu.tsx
@@ -1,5 +1,3 @@
-import { useStore } from "@tanstack/react-store";
-
 import { TableViewMenuPage } from "@notion-kit/table-hook";
 import type { ColumnInfo } from "@notion-kit/table-hook";
 import { IconBlock } from "@notion-kit/ui/icon-block";
@@ -20,27 +18,6 @@ import { useTableViewCtx } from "@/table-contexts";
 
 export function SelectGroupMenu() {
   const { table } = useTableViewCtx();
-  const columnOrder = useStore(table.atoms.columnOrder, (state) => state);
-  const columnsInfo = useStore(table.atoms.columnsInfo, (state) => state);
-  const grouping = useStore(table.atoms.grouping, (state) => state);
-  const tableGlobal = useStore(table.atoms.tableGlobal, (state) => state);
-  const groupingColId = grouping.at(0);
-
-  const options = columnOrder.reduce<(ColumnInfo & { kind: "column" })[]>(
-    (acc, colId) => {
-      const col = columnsInfo[colId]!;
-      if (col.hidden || col.isDeleted) return acc;
-      acc.push({ ...col, kind: "column" });
-      return acc;
-    },
-    [],
-  );
-  const groupOptions = [
-    ...(tableGlobal.layout !== "board"
-      ? [{ kind: "none" as const, id: null, name: "None" }]
-      : []),
-    ...options,
-  ];
 
   const selectGroup = (colId: string | null) => {
     table.setGroupingColumn(colId);
@@ -51,60 +28,91 @@ export function SelectGroupMenu() {
   };
 
   return (
-    <>
-      <MenuHeader
-        title="Group by"
-        onBack={() =>
-          table.setTableMenuState({
-            open: true,
-            page: grouping.length > 0 ? TableViewMenuPage.EditGroupBy : null,
-          })
-        }
-      />
-      <Autocomplete
-        items={groupOptions}
-        itemToStringValue={(option) => option.name}
-        open
-        autoHighlight="always"
-        openOnInputClick
-      >
-        <AutocompleteInput
-          placeholder="Search for a property"
-          onKeyDown={(e) => e.stopPropagation()}
-        />
-        <AutocompleteContent variant="inline">
-          <AutocompleteList>
-            <AutocompleteGroup className="h-40">
-              <AutocompleteCollection>
-                {(option: (typeof groupOptions)[number]) => (
-                  <AutocompleteItem
-                    key={option.id ?? "none"}
-                    value={option}
-                    label={option.name}
-                    icon={
-                      option.kind === "column" ? (
-                        option.icon ? (
-                          <IconBlock icon={option.icon} />
-                        ) : (
-                          <DefaultIcon type={option.type} />
-                        )
-                      ) : null
-                    }
-                    onClick={() => selectGroup(option.id)}
-                  >
-                    {groupingColId === (option.id ?? undefined) && (
-                      <MenuItemCheck />
-                    )}
-                  </AutocompleteItem>
-                )}
-              </AutocompleteCollection>
-            </AutocompleteGroup>
-          </AutocompleteList>
-          <AutocompleteEmpty className="px-3 text-start text-muted">
-            No results
-          </AutocompleteEmpty>
-        </AutocompleteContent>
-      </Autocomplete>
-    </>
+    <table.Subscribe
+      selector={(state) => ({
+        columnOrder: state.columnOrder,
+        columnsInfo: state.columnsInfo,
+        grouping: state.grouping,
+        tableGlobal: state.tableGlobal,
+      })}
+    >
+      {({ columnOrder, columnsInfo, grouping, tableGlobal }) => {
+        const groupingColId = grouping.at(0);
+        const options = columnOrder.reduce<(ColumnInfo & { kind: "column" })[]>(
+          (acc, colId) => {
+            const col = columnsInfo[colId]!;
+            if (col.hidden || col.isDeleted) return acc;
+            acc.push({ ...col, kind: "column" });
+            return acc;
+          },
+          [],
+        );
+        const groupOptions = [
+          ...(tableGlobal.layout !== "board"
+            ? [{ kind: "none" as const, id: null, name: "None" }]
+            : []),
+          ...options,
+        ];
+
+        return (
+          <>
+            <MenuHeader
+              title="Group by"
+              onBack={() =>
+                table.setTableMenuState({
+                  open: true,
+                  page:
+                    grouping.length > 0 ? TableViewMenuPage.EditGroupBy : null,
+                })
+              }
+            />
+            <Autocomplete
+              items={groupOptions}
+              itemToStringValue={(option) => option.name}
+              open
+              autoHighlight="always"
+              openOnInputClick
+            >
+              <AutocompleteInput
+                placeholder="Search for a property"
+                onKeyDown={(e) => e.stopPropagation()}
+              />
+              <AutocompleteContent variant="inline">
+                <AutocompleteList>
+                  <AutocompleteGroup className="h-40">
+                    <AutocompleteCollection>
+                      {(option: (typeof groupOptions)[number]) => (
+                        <AutocompleteItem
+                          key={option.id ?? "none"}
+                          value={option}
+                          label={option.name}
+                          icon={
+                            option.kind === "column" ? (
+                              option.icon ? (
+                                <IconBlock icon={option.icon} />
+                              ) : (
+                                <DefaultIcon type={option.type} />
+                              )
+                            ) : null
+                          }
+                          onClick={() => selectGroup(option.id)}
+                        >
+                          {groupingColId === (option.id ?? undefined) && (
+                            <MenuItemCheck />
+                          )}
+                        </AutocompleteItem>
+                      )}
+                    </AutocompleteCollection>
+                  </AutocompleteGroup>
+                </AutocompleteList>
+                <AutocompleteEmpty className="px-3 text-start text-muted">
+                  No results
+                </AutocompleteEmpty>
+              </AutocompleteContent>
+            </Autocomplete>
+          </>
+        );
+      }}
+    </table.Subscribe>
   );
 }

--- a/packages/table-view/src/menus/select-group-menu.tsx
+++ b/packages/table-view/src/menus/select-group-menu.tsx
@@ -1,3 +1,5 @@
+import { useStore } from "@tanstack/react-store";
+
 import { TableViewMenuPage } from "@notion-kit/table-hook";
 import type { ColumnInfo } from "@notion-kit/table-hook";
 import { IconBlock } from "@notion-kit/ui/icon-block";
@@ -18,7 +20,10 @@ import { useTableViewCtx } from "@/table-contexts";
 
 export function SelectGroupMenu() {
   const { table } = useTableViewCtx();
-  const { columnOrder, columnsInfo, grouping, tableGlobal } = table.store.state;
+  const columnOrder = useStore(table.atoms.columnOrder, (state) => state);
+  const columnsInfo = useStore(table.atoms.columnsInfo, (state) => state);
+  const grouping = useStore(table.atoms.grouping, (state) => state);
+  const tableGlobal = useStore(table.atoms.tableGlobal, (state) => state);
   const groupingColId = grouping.at(0);
 
   const options = columnOrder.reduce<(ColumnInfo & { kind: "column" })[]>(

--- a/packages/table-view/src/menus/sort-menu.tsx
+++ b/packages/table-view/src/menus/sort-menu.tsx
@@ -76,6 +76,7 @@ function SortMenuContent({
       <DropdownMenuGroup>
         <Popover open={addingSort} onOpenChange={setAddingSort}>
           <PopoverTrigger
+            nativeButton={false}
             render={
               <DropdownMenuItem
                 closeOnClick={false}

--- a/packages/table-view/src/menus/sort-menu.tsx
+++ b/packages/table-view/src/menus/sort-menu.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import type { DragEndEvent } from "@dnd-kit/react";
+import { useStore } from "@tanstack/react-store";
 import type { ColumnSort } from "@tanstack/react-table";
 
 import { Icon } from "@notion-kit/icons";
+import type { TableInstance } from "@notion-kit/table-hook";
 import { IconBlock } from "@notion-kit/ui/icon-block";
 import {
   Autocomplete,
@@ -51,9 +53,7 @@ export function SortMenu() {
 function SortMenuContent({
   sorting,
 }: {
-  sorting: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["sorting"];
+  sorting: ReturnType<TableInstance["atoms"]["sorting"]["get"]>;
 }) {
   const { table } = useTableViewCtx();
   const [addingSort, setAddingSort] = useState(false);
@@ -112,7 +112,9 @@ function SortRule({ id: currentId, desc, index }: SortRuleProps) {
   const { table } = useTableViewCtx();
 
   const current = table.getColumnInfo(currentId);
-  const properties = Object.values(table.store.state.columnsInfo);
+  const properties = useStore(table.atoms.columnsInfo, (state) =>
+    Object.values(state),
+  );
 
   const updateRule = (columnSort: ColumnSort) =>
     table.setSorting((prev) =>
@@ -120,7 +122,7 @@ function SortRule({ id: currentId, desc, index }: SortRuleProps) {
     );
   const removeRule = () => {
     table.setSorting((prev) => prev.filter((s) => s.id !== currentId));
-    const isLastRule = table.store.state.sorting.length === 1;
+    const isLastRule = table.atoms.sorting.get().length === 1;
     if (isLastRule) {
       // TODO close popover
     }
@@ -245,12 +247,8 @@ function PropSelectMenuContent({
   sorting,
   onSelect,
 }: {
-  columnsInfo: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["columnsInfo"];
-  sorting: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["sorting"];
+  columnsInfo: ReturnType<TableInstance["atoms"]["columnsInfo"]["get"]>;
+  sorting: ReturnType<TableInstance["atoms"]["sorting"]["get"]>;
   onSelect: () => void;
 }) {
   const { table } = useTableViewCtx();

--- a/packages/table-view/src/menus/sort-menu.tsx
+++ b/packages/table-view/src/menus/sort-menu.tsx
@@ -1,10 +1,8 @@
 import { useState } from "react";
 import type { DragEndEvent } from "@dnd-kit/react";
-import { useStore } from "@tanstack/react-store";
 import type { ColumnSort } from "@tanstack/react-table";
 
 import { Icon } from "@notion-kit/icons";
-import type { TableInstance } from "@notion-kit/table-hook";
 import { IconBlock } from "@notion-kit/ui/icon-block";
 import {
   Autocomplete,
@@ -37,25 +35,6 @@ import { useTableViewCtx } from "@/table-contexts";
 
 export function SortMenu() {
   const { table } = useTableViewCtx();
-
-  return (
-    <table.Subscribe
-      selector={(state) => ({
-        sorting: state.sorting,
-        columnsInfo: state.columnsInfo,
-      })}
-    >
-      {({ sorting }) => <SortMenuContent sorting={sorting} />}
-    </table.Subscribe>
-  );
-}
-
-function SortMenuContent({
-  sorting,
-}: {
-  sorting: ReturnType<TableInstance["atoms"]["sorting"]["get"]>;
-}) {
-  const { table } = useTableViewCtx();
   const [addingSort, setAddingSort] = useState(false);
 
   const reorderRules = (e: DragEndEvent) => {
@@ -65,18 +44,23 @@ function SortMenuContent({
   return (
     <>
       <DropdownMenuGroup>
-        <Sortable.Root onDragEnd={reorderRules}>
-          <Sortable.List>
-            {sorting.map((prop, index) => (
-              <SortRule key={prop.id} {...prop} index={index} />
-            ))}
-          </Sortable.List>
-        </Sortable.Root>
+        <table.Subscribe selector={(state) => state.sorting}>
+          {(sorting) => (
+            <Sortable.Root onDragEnd={reorderRules}>
+              <Sortable.List>
+                {sorting.map((prop, index) => (
+                  <SortRule key={prop.id} {...prop} index={index} />
+                ))}
+              </Sortable.List>
+            </Sortable.Root>
+          )}
+        </table.Subscribe>
       </DropdownMenuGroup>
       <DropdownMenuGroup>
         <Popover open={addingSort} onOpenChange={setAddingSort}>
           <PopoverTrigger
             nativeButton={false}
+            role="menuitem" // override the default role: button
             render={
               <DropdownMenuItem
                 closeOnClick={false}
@@ -112,11 +96,6 @@ interface SortRuleProps {
 function SortRule({ id: currentId, desc, index }: SortRuleProps) {
   const { table } = useTableViewCtx();
 
-  const current = table.getColumnInfo(currentId);
-  const properties = useStore(table.atoms.columnsInfo, (state) =>
-    Object.values(state),
-  );
-
   const updateRule = (columnSort: ColumnSort) =>
     table.setSorting((prev) =>
       prev.map((s) => (s.id === currentId ? columnSort : s)),
@@ -130,100 +109,114 @@ function SortRule({ id: currentId, desc, index }: SortRuleProps) {
   };
 
   return (
-    <Sortable.Item
-      id={currentId}
-      index={index}
-      render={
-        <DropdownMenuItem
-          closeOnClick={false}
-          className="h-9"
-          icon={<Sortable.Handle aria-label={`Move ${current.name}`} />}
-          label={
-            <div className="grid h-8 w-full grid-cols-2 items-center gap-1.5">
-              <Select
-                value={currentId}
-                onValueChange={(id) => {
-                  if (id !== null) updateRule({ id, desc });
-                }}
-              >
-                <SelectTrigger
-                  aria-label={current.name}
-                  className="my-0 w-full max-w-45 border border-border"
-                >
-                  <SelectValue aria-label={current.name}>
-                    <div className="flex items-center gap-2 truncate">
-                      {current.icon ? (
-                        <IconBlock icon={current.icon} />
-                      ) : (
-                        <DefaultIcon type={current.type} />
-                      )}
-                      {current.name}
-                    </div>
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    {properties.map(({ id, name, type, icon }) => (
-                      <SelectItem
-                        key={id}
-                        value={id}
-                        label={name}
-                        icon={
-                          icon ? (
-                            <IconBlock icon={icon} />
-                          ) : (
-                            <DefaultIcon type={type} />
-                          )
-                        }
-                      />
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-              <Select
-                value={desc ? "desc" : "asc"}
-                onValueChange={(value) =>
-                  updateRule({ id: currentId, desc: value === "desc" })
+    <table.Subscribe selector={(state) => state.columnsInfo}>
+      {(columnsInfo) => {
+        const current = columnsInfo[currentId]!;
+        const properties = Object.values(columnsInfo);
+
+        return (
+          <Sortable.Item
+            id={currentId}
+            index={index}
+            render={
+              <DropdownMenuItem
+                closeOnClick={false}
+                className="h-9"
+                icon={<Sortable.Handle aria-label={`Move ${current.name}`} />}
+                label={
+                  <div className="grid h-8 w-full grid-cols-2 items-center gap-1.5">
+                    <Select
+                      value={currentId}
+                      onValueChange={(id) => {
+                        if (id !== null) updateRule({ id, desc });
+                      }}
+                    >
+                      <SelectTrigger
+                        aria-label={current.name}
+                        className="my-0 w-full max-w-45 border border-border"
+                      >
+                        <SelectValue aria-label={current.name}>
+                          <div className="flex items-center gap-2 truncate">
+                            {current.icon ? (
+                              <IconBlock icon={current.icon} />
+                            ) : (
+                              <DefaultIcon type={current.type} />
+                            )}
+                            {current.name}
+                          </div>
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {properties.map(({ id, name, type, icon }) => (
+                            <SelectItem
+                              key={id}
+                              value={id}
+                              label={name}
+                              icon={
+                                icon ? (
+                                  <IconBlock icon={icon} />
+                                ) : (
+                                  <DefaultIcon type={type} />
+                                )
+                              }
+                            />
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                    <Select
+                      value={desc ? "desc" : "asc"}
+                      onValueChange={(value) =>
+                        updateRule({ id: currentId, desc: value === "desc" })
+                      }
+                    >
+                      <SelectTrigger
+                        aria-label={desc ? "Descending" : "Ascending"}
+                        className="my-0 w-full max-w-45 border border-border"
+                      >
+                        <SelectValue aria-label={desc ? "desc" : "asc"}>
+                          <span className="truncate">
+                            {desc ? "Descending" : "Ascending"}
+                          </span>
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          <SelectItem value="asc" label="Ascending" />
+                          <SelectItem value="desc" label="Descending" />
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  </div>
                 }
+              />
+            }
+          >
+            <MenuItemAction className="flex items-center">
+              <Button
+                variant="hint"
+                className="size-5"
+                aria-label={`Remove ${current.name} sort`}
+                onClick={removeRule}
               >
-                <SelectTrigger
-                  aria-label={desc ? "Descending" : "Ascending"}
-                  className="my-0 w-full max-w-45 border border-border"
-                >
-                  <SelectValue aria-label={desc ? "desc" : "asc"}>
-                    <span className="truncate">
-                      {desc ? "Descending" : "Ascending"}
-                    </span>
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectItem value="asc" label="Ascending" />
-                    <SelectItem value="desc" label="Descending" />
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </div>
-          }
-        />
-      }
-    >
-      <MenuItemAction className="flex items-center">
-        <Button
-          variant="hint"
-          className="size-5"
-          aria-label={`Remove ${current.name} sort`}
-          onClick={removeRule}
-        >
-          <Icon.Close className="fill-current" />
-        </Button>
-      </MenuItemAction>
-    </Sortable.Item>
+                <Icon.Close className="fill-current" />
+              </Button>
+            </MenuItemAction>
+          </Sortable.Item>
+        );
+      }}
+    </table.Subscribe>
   );
 }
 
 function PropSelectMenu({ onSelect }: { onSelect: () => void }) {
   const { table } = useTableViewCtx();
+
+  const selectProp = (id: string) => {
+    table.setSorting((prev) => [...prev, { id, desc: false }]);
+    onSelect();
+  };
 
   return (
     <table.Subscribe
@@ -232,75 +225,54 @@ function PropSelectMenu({ onSelect }: { onSelect: () => void }) {
         sorting: state.sorting,
       })}
     >
-      {({ columnsInfo, sorting }) => (
-        <PropSelectMenuContent
-          columnsInfo={columnsInfo}
-          sorting={sorting}
-          onSelect={onSelect}
-        />
-      )}
+      {({ columnsInfo, sorting }) => {
+        const columns = Object.values(columnsInfo);
+        /** Select */
+        const sortedProps = new Set(sorting.map((s) => s.id));
+
+        return (
+          <Autocomplete
+            items={columns}
+            itemToStringValue={(column) => column.name}
+            open
+            autoHighlight="always"
+            openOnInputClick
+          >
+            <AutocompleteInput
+              clear
+              placeholder="Search for a property..."
+              onKeyDown={(event) => event.stopPropagation()}
+            />
+            <AutocompleteContent variant="inline">
+              <AutocompleteList>
+                <AutocompleteGroup className="h-40 overflow-y-auto">
+                  <AutocompleteCollection>
+                    {(column: (typeof columns)[number]) => (
+                      <AutocompleteItem
+                        key={column.id}
+                        value={column}
+                        onClick={() => selectProp(column.id)}
+                        disabled={sortedProps.has(column.id)}
+                        icon={
+                          column.icon ? (
+                            <IconBlock icon={column.icon} />
+                          ) : (
+                            <DefaultIcon type={column.type} />
+                          )
+                        }
+                        label={column.name}
+                      />
+                    )}
+                  </AutocompleteCollection>
+                </AutocompleteGroup>
+              </AutocompleteList>
+              <AutocompleteEmpty className="px-3 text-start text-muted">
+                No results
+              </AutocompleteEmpty>
+            </AutocompleteContent>
+          </Autocomplete>
+        );
+      }}
     </table.Subscribe>
-  );
-}
-
-function PropSelectMenuContent({
-  columnsInfo,
-  sorting,
-  onSelect,
-}: {
-  columnsInfo: ReturnType<TableInstance["atoms"]["columnsInfo"]["get"]>;
-  sorting: ReturnType<TableInstance["atoms"]["sorting"]["get"]>;
-  onSelect: () => void;
-}) {
-  const { table } = useTableViewCtx();
-  const columns = Object.values(columnsInfo);
-  /** Select */
-  const sortedProps = new Set(sorting.map((s) => s.id));
-  const selectProp = (id: string) => {
-    table.setSorting((prev) => [...prev, { id, desc: false }]);
-    onSelect();
-  };
-
-  return (
-    <Autocomplete
-      items={columns}
-      itemToStringValue={(column) => column.name}
-      open
-      autoHighlight="always"
-      openOnInputClick
-    >
-      <AutocompleteInput
-        clear
-        placeholder="Search for a property..."
-        onKeyDown={(event) => event.stopPropagation()}
-      />
-      <AutocompleteContent variant="inline">
-        <AutocompleteList>
-          <AutocompleteGroup className="h-40 overflow-y-auto">
-            <AutocompleteCollection>
-              {(column: (typeof columns)[number]) => (
-                <AutocompleteItem
-                  key={column.id}
-                  value={column}
-                  onClick={() => selectProp(column.id)}
-                  disabled={sortedProps.has(column.id)}
-                  icon={
-                    column.icon ? (
-                      <IconBlock icon={column.icon} />
-                    ) : (
-                      <DefaultIcon type={column.type} />
-                    )
-                  }
-                  label={column.name}
-                />
-              )}
-            </AutocompleteCollection>
-          </AutocompleteGroup>
-        </AutocompleteList>
-        <AutocompleteEmpty className="px-3 text-start text-muted">
-          No results
-        </AutocompleteEmpty>
-      </AutocompleteContent>
-    </Autocomplete>
   );
 }

--- a/packages/table-view/src/menus/types-menu.tsx
+++ b/packages/table-view/src/menus/types-menu.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useStore } from "@tanstack/react-store";
 import { v4 } from "uuid";
 
 import { TableViewMenuPage } from "@notion-kit/table-hook";
@@ -47,9 +46,6 @@ interface TypesMenuProps {
 
 export function TypesMenu({ propId, at, menu, back }: TypesMenuProps) {
   const { table } = useTableViewCtx();
-
-  const plugins = useStore(table.atoms.cellPlugins, (state) => state);
-  const pluginOptions = Object.values(plugins);
   const propType = propId ? table.getColumnInfo(propId).type : null;
   const [search, setSearch] = useState("");
 
@@ -93,61 +89,69 @@ export function TypesMenu({ propId, at, menu, back }: TypesMenuProps) {
           }
         />
       )}
-      <Autocomplete
-        items={pluginOptions}
-        itemToStringValue={(plugin) => plugin.default.name}
-        value={search}
-        onValueChange={setSearch}
-        open
-        autoHighlight="always"
-        openOnInputClick
-      >
-        <AutocompleteInput
-          placeholder={
-            propId ? "Search for property type" : "Search or add new property"
-          }
-          onKeyDown={(e) => e.stopPropagation()}
-        />
-        <AutocompleteContent variant="inline">
-          <AutocompleteList>
-            <AutocompleteGroup>
-              <AutocompleteLabel title="Type" />
-              <AutocompleteCollection>
-                {(plugin: CellPlugin) => (
-                  <TooltipPreset
-                    key={plugin.id}
-                    side="left"
-                    sideOffset={6}
-                    description={plugin.meta.desc}
-                    className="max-w-[282px] text-xs/[1.4]"
-                  >
+      <table.Subscribe selector={(state) => state.cellPlugins}>
+        {(plugins) => (
+          <Autocomplete
+            items={Object.values(plugins)}
+            itemToStringValue={(plugin) => plugin.default.name}
+            value={search}
+            onValueChange={setSearch}
+            open
+            autoHighlight="always"
+            openOnInputClick
+          >
+            <AutocompleteInput
+              placeholder={
+                propId
+                  ? "Search for property type"
+                  : "Search or add new property"
+              }
+              onKeyDown={(e) => e.stopPropagation()}
+            />
+            <AutocompleteContent variant="inline">
+              <AutocompleteList>
+                <AutocompleteGroup>
+                  <AutocompleteLabel title="Type" />
+                  <AutocompleteCollection>
+                    {(plugin: CellPlugin) => (
+                      <TooltipPreset
+                        key={plugin.id}
+                        side="left"
+                        sideOffset={6}
+                        description={plugin.meta.desc}
+                        className="max-w-[282px] text-xs/[1.4]"
+                      >
+                        <AutocompleteItem
+                          value={plugin}
+                          disabled={plugin.id === "title"}
+                          icon={plugin.meta.icon}
+                          label={plugin.meta.name}
+                          onClick={() => select(plugin.id, plugin.meta.name)}
+                        >
+                          {propType === plugin.id && <MenuItemCheck />}
+                        </AutocompleteItem>
+                      </TooltipPreset>
+                    )}
+                  </AutocompleteCollection>
+                </AutocompleteGroup>
+                {!propId && search.length > 0 && (
+                  <AutocompleteGroup>
+                    <AutocompleteLabel title="Select to add" />
                     <AutocompleteItem
-                      value={plugin}
-                      disabled={plugin.id === "title"}
-                      icon={plugin.meta.icon}
-                      label={plugin.meta.name}
-                      onClick={() => select(plugin.id, plugin.meta.name)}
-                    >
-                      {propType === plugin.id && <MenuItemCheck />}
-                    </AutocompleteItem>
-                  </TooltipPreset>
+                      value={`search-${search}`}
+                      icon={
+                        <DefaultIcon type="text" className="fill-menu-icon" />
+                      }
+                      label={search}
+                      onClick={() => select("text", search)}
+                    />
+                  </AutocompleteGroup>
                 )}
-              </AutocompleteCollection>
-            </AutocompleteGroup>
-            {!propId && search.length > 0 && (
-              <AutocompleteGroup>
-                <AutocompleteLabel title="Select to add" />
-                <AutocompleteItem
-                  value={`search-${search}`}
-                  icon={<DefaultIcon type="text" className="fill-menu-icon" />}
-                  label={search}
-                  onClick={() => select("text", search)}
-                />
-              </AutocompleteGroup>
-            )}
-          </AutocompleteList>
-        </AutocompleteContent>
-      </Autocomplete>
+              </AutocompleteList>
+            </AutocompleteContent>
+          </Autocomplete>
+        )}
+      </table.Subscribe>
     </>
   );
 }

--- a/packages/table-view/src/menus/types-menu.tsx
+++ b/packages/table-view/src/menus/types-menu.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useStore } from "@tanstack/react-store";
 import { v4 } from "uuid";
 
 import { TableViewMenuPage } from "@notion-kit/table-hook";
@@ -47,7 +48,7 @@ interface TypesMenuProps {
 export function TypesMenu({ propId, at, menu, back }: TypesMenuProps) {
   const { table } = useTableViewCtx();
 
-  const plugins = table.store.state.cellPlugins;
+  const plugins = useStore(table.atoms.cellPlugins, (state) => state);
   const pluginOptions = Object.values(plugins);
   const propType = propId ? table.getColumnInfo(propId).type : null;
   const [search, setSearch] = useState("");

--- a/packages/table-view/src/plugins/date/common/date-format-menu.tsx
+++ b/packages/table-view/src/plugins/date/common/date-format-menu.tsx
@@ -34,6 +34,7 @@ export function DateFormatMenu({
     <DropdownMenu>
       <DropdownMenuTrigger
         nativeButton={false}
+        role="menuitem" // override the default role: button
         render={
           <MenuItem
             icon={showIcon ? <Icon.ViewCalendar /> : undefined}

--- a/packages/table-view/src/plugins/date/common/date-format-menu.tsx
+++ b/packages/table-view/src/plugins/date/common/date-format-menu.tsx
@@ -33,6 +33,7 @@ export function DateFormatMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
+        nativeButton={false}
         render={
           <MenuItem
             icon={showIcon ? <Icon.ViewCalendar /> : undefined}

--- a/packages/table-view/src/plugins/date/common/time-format-menu.tsx
+++ b/packages/table-view/src/plugins/date/common/time-format-menu.tsx
@@ -31,6 +31,7 @@ export function TimeFormatMenu({
     <DropdownMenu>
       <DropdownMenuTrigger
         nativeButton={false}
+        role="menuitem" // override the default role: button
         render={
           <MenuItem
             label="Time format"

--- a/packages/table-view/src/plugins/date/common/time-format-menu.tsx
+++ b/packages/table-view/src/plugins/date/common/time-format-menu.tsx
@@ -30,6 +30,7 @@ export function TimeFormatMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
+        nativeButton={false}
         render={
           <MenuItem
             label="Time format"

--- a/packages/table-view/src/plugins/date/date-cell/date-cell.test.tsx
+++ b/packages/table-view/src/plugins/date/date-cell/date-cell.test.tsx
@@ -218,6 +218,28 @@ it("DateRangeInput_UnchangedBlur_DoesNotReportRedundantTimestamp", async () => {
   expect(onChange).not.toHaveBeenCalled();
 });
 
+it("DateRangeInput_UnchangedDateTimeBlur_DoesNotReportRedundantTimestamp", async () => {
+  // Arrange
+  const user = userEvent.setup();
+  const onChange = vi.fn();
+  render(
+    <DateRangeInput
+      value={{ includeTime: true, start: Date.UTC(2025, 0, 15, 13, 45) }}
+      onChange={onChange}
+      tz="UTC"
+    />,
+  );
+  const [dateInput, timeInput] = screen.getAllByRole("textbox");
+
+  // Act
+  await user.click(dateInput!);
+  await user.click(timeInput!);
+  await user.tab();
+
+  // Assert
+  expect(onChange).not.toHaveBeenCalled();
+});
+
 it("DateRangeInput_UntouchedEmptyThenInvalidBlur_SuppressesOnlyEmptyMutation", async () => {
   // Arrange
   const user = userEvent.setup();

--- a/packages/table-view/src/plugins/date/date-cell/date-range-input.tsx
+++ b/packages/table-view/src/plugins/date/date-cell/date-range-input.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useEffect, useState } from "react";
 import type { OnChangeFn } from "@tanstack/react-table";
 import * as z from "zod/v4/mini";
@@ -151,17 +149,9 @@ interface DateInputProps {
 
 function DateInput({ id, value: ts, onChange, tz }: DateInputProps) {
   const [error, setError] = useState(false);
-  const getValue = () => {
-    if (ts === undefined || ts < 0) return "";
-    return formatDate(ts, {
-      dateFormat: "_edit_mode",
-      timeFormat: "hidden",
-      tz,
-    });
-  };
-  const [value, setValue] = useState(getValue);
-  // eslint-disable-next-line react-hooks/set-state-in-effect, react-hooks/exhaustive-deps -- Calendar selections must refresh the controlled editor draft.
-  useEffect(() => setValue(getValue()), [ts]);
+  const [value, setValue] = useState(getTimeValue(ts, tz));
+
+  // useEffect(() => setValue(getTimeValue(ts, tz)), [ts, tz]);
 
   const handleBlur = () => {
     const res = dateTimeSchema.safeParse({ date: value, time: "" });
@@ -182,4 +172,13 @@ function DateInput({ id, value: ts, onChange, tz }: DateInputProps) {
       onBlur={handleBlur}
     />
   );
+}
+
+function getTimeValue(ts?: number, tz?: string) {
+  if (ts === undefined || ts < 0) return "";
+  return formatDate(ts, {
+    dateFormat: "_edit_mode",
+    timeFormat: "hidden",
+    tz,
+  });
 }

--- a/packages/table-view/src/plugins/date/date-cell/date-range-input.tsx
+++ b/packages/table-view/src/plugins/date/date-cell/date-range-input.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { OnChangeFn } from "@tanstack/react-table";
-import z from "zod/v4";
+import * as z from "zod/v4/mini";
 
 import { cn } from "@notion-kit/cn";
 import { Input, Separator } from "@notion-kit/ui/primitives";
@@ -11,8 +11,11 @@ import { formatDate, isoToTs } from "@notion-kit/utils";
 import type { DateData } from "../types";
 
 const dateTimeSchema = z.object({
-  date: z.iso.date().or(z.literal("")),
-  time: z.iso.time({ precision: 0 }).or(z.literal("")).default("00:00:00"),
+  date: z.union([z.iso.date(), z.literal("")]),
+  time: z._default(
+    z.union([z.iso.time({ precision: 0 }), z.literal("")]),
+    "00:00:00",
+  ),
 });
 type DateTimeSchema = z.infer<typeof dateTimeSchema>;
 
@@ -91,6 +94,7 @@ function DateTimeInput({ id, value: ts, onChange, tz }: DateTimeInputProps) {
     const [date, time] = formatDate(ts, {
       dateFormat: "_edit_mode",
       timeFormat: "_edit_mode",
+      tz,
     }).split(" ");
     return { date: date!, time: time! };
   };
@@ -100,7 +104,8 @@ function DateTimeInput({ id, value: ts, onChange, tz }: DateTimeInputProps) {
   const handleBlur = () => {
     const res = dateTimeSchema.safeParse(value);
     setError(!res.success);
-    onChange(res.success ? parsedDateTimeToTs(res.data, tz) : -1);
+    const nextTs = res.success ? parsedDateTimeToTs(res.data, tz) : -1;
+    if (nextTs !== ts) onChange(nextTs);
   };
 
   return (
@@ -151,6 +156,7 @@ function DateInput({ id, value: ts, onChange, tz }: DateInputProps) {
     return formatDate(ts, {
       dateFormat: "_edit_mode",
       timeFormat: "hidden",
+      tz,
     });
   };
   const [value, setValue] = useState(getValue);

--- a/packages/table-view/src/plugins/number/number-config-menu/option-settings.tsx
+++ b/packages/table-view/src/plugins/number/number-config-menu/option-settings.tsx
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import * as z from "zod/v4/mini";
 
 import {
   Input,

--- a/packages/table-view/src/plugins/number/plugin.tsx
+++ b/packages/table-view/src/plugins/number/plugin.tsx
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import * as z from "zod/v4/mini";
 
 import { DefaultIcon } from "@/common";
 
@@ -7,10 +7,10 @@ import { NumberCell } from "./number-cell";
 import { NumberConfigMenu } from "./number-config-menu";
 import type { NumberPlugin } from "./types";
 
-const numberSchema = z
-  .any()
-  .refine((val) => !isNaN(Number(val)))
-  .transform(String);
+const numberSchema = z.pipe(
+  z.custom((value) => !isNaN(Number(value))),
+  z.transform((value) => String(value)),
+);
 
 export function number(): NumberPlugin {
   return {

--- a/packages/table-view/src/row-view/dialog-view.tsx
+++ b/packages/table-view/src/row-view/dialog-view.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { cn } from "@notion-kit/cn";
+import type { TableInstance } from "@notion-kit/table-hook";
 import { Dialog, DialogContent, DialogTitle } from "@notion-kit/ui/primitives";
 
 import { useTableViewCtx } from "@/table-contexts";
@@ -33,9 +34,7 @@ function DialogViewContent({
   children,
   tableGlobal,
 }: React.PropsWithChildren<{
-  tableGlobal: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["tableGlobal"];
+  tableGlobal: ReturnType<TableInstance["atoms"]["tableGlobal"]["get"]>;
 }>) {
   const { table } = useTableViewCtx();
   const { rowView, openedRowId } = tableGlobal;

--- a/packages/table-view/src/row-view/full-view.tsx
+++ b/packages/table-view/src/row-view/full-view.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { cn } from "@notion-kit/cn";
+import type { TableInstance } from "@notion-kit/table-hook";
 import { typography } from "@notion-kit/ui/primitives";
 
 import { useTableViewCtx } from "@/table-contexts";
@@ -31,9 +32,7 @@ function FullViewContent({
   children,
   tableGlobal,
 }: React.PropsWithChildren<{
-  tableGlobal: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["tableGlobal"];
+  tableGlobal: ReturnType<TableInstance["atoms"]["tableGlobal"]["get"]>;
 }>) {
   const headingTypographyClassName = typography("h1");
   const { table } = useTableViewCtx();

--- a/packages/table-view/src/row-view/side-view.tsx
+++ b/packages/table-view/src/row-view/side-view.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { cn } from "@notion-kit/cn";
+import type { TableInstance } from "@notion-kit/table-hook";
 import { Sheet, SheetContent, SheetTitle } from "@notion-kit/ui/primitives";
 
 import { useTableViewCtx } from "@/table-contexts";
@@ -31,9 +32,7 @@ function SideViewContent({
   children,
   tableGlobal,
 }: React.PropsWithChildren<{
-  tableGlobal: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["tableGlobal"];
+  tableGlobal: ReturnType<TableInstance["atoms"]["tableGlobal"]["get"]>;
 }>) {
   const { table } = useTableViewCtx();
   const { rowView, openedRowId } = tableGlobal;

--- a/packages/table-view/src/table-body/table-body.tsx
+++ b/packages/table-view/src/table-body/table-body.tsx
@@ -12,7 +12,6 @@ import { TableGroupedRow } from "./table-grouped-row";
 import { TableRow } from "./table-row";
 
 export function DndTableBody() {
-  const [dialogOpen, setDialogOpen] = useState(false);
   const [pendingDragEndEvent, setPendingDragEndEvent] =
     useState<DragEndEvent | null>(null);
   const { table } = useTableViewCtx();
@@ -37,8 +36,6 @@ export function DndTableBody() {
           locked={locked ?? false}
           sorting={sorting}
           isResizingColumn={Boolean(columnResizing.isResizingColumn)}
-          dialogOpen={dialogOpen}
-          setDialogOpen={setDialogOpen}
           pendingDragEndEvent={pendingDragEndEvent}
           setPendingDragEndEvent={setPendingDragEndEvent}
         />
@@ -51,8 +48,6 @@ interface DndTableBodyContentProps {
   locked: boolean;
   sorting: ReturnType<TableInstance["atoms"]["sorting"]["get"]>;
   isResizingColumn: boolean;
-  dialogOpen: boolean;
-  setDialogOpen: (open: boolean) => void;
   pendingDragEndEvent: DragEndEvent | null;
   setPendingDragEndEvent: (event: DragEndEvent | null) => void;
 }
@@ -61,8 +56,6 @@ function DndTableBodyContent({
   locked,
   sorting,
   isResizingColumn,
-  dialogOpen,
-  setDialogOpen,
   pendingDragEndEvent,
   setPendingDragEndEvent,
 }: DndTableBodyContentProps) {
@@ -73,18 +66,16 @@ function DndTableBodyContent({
       const isSorted = sorting.length > 0;
       if (!isSorted) return table.handleRowDragEnd(e);
       setPendingDragEndEvent(e);
-      setDialogOpen(true);
     },
-    [setDialogOpen, setPendingDragEndEvent, sorting.length, table],
+    [setPendingDragEndEvent, sorting.length, table],
   );
 
   const handleConfirmRemoveSorting = () => {
     if (pendingDragEndEvent) {
       table.resetSorting();
       table.handleRowDragEnd(pendingDragEndEvent);
-      setPendingDragEndEvent(null);
     }
-    setDialogOpen(false);
+    setPendingDragEndEvent(null);
   };
 
   return (
@@ -137,7 +128,12 @@ function DndTableBodyContent({
           </span>
         </Button>
       )}
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <Dialog
+        open={pendingDragEndEvent !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDragEndEvent(null);
+        }}
+      >
         <AlertModal
           title="Would you like to remove sorting?"
           primary="Remove"

--- a/packages/table-view/src/table-body/table-body.tsx
+++ b/packages/table-view/src/table-body/table-body.tsx
@@ -49,7 +49,7 @@ export function DndTableBody() {
 
 interface DndTableBodyContentProps {
   locked: boolean;
-  sorting: TableInstance["store"]["state"]["sorting"];
+  sorting: ReturnType<TableInstance["atoms"]["sorting"]["get"]>;
   isResizingColumn: boolean;
   dialogOpen: boolean;
   setDialogOpen: (open: boolean) => void;

--- a/packages/table-view/src/table-contexts/table-view-content.tsx
+++ b/packages/table-view/src/table-contexts/table-view-content.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 
 import { Icon } from "@notion-kit/icons";
+import type { TableInstance } from "@notion-kit/table-hook";
 import { Button, Separator } from "@notion-kit/ui/primitives";
 
 import { DndTableBody } from "../table-body";
@@ -26,15 +27,9 @@ export function TableViewContent() {
 }
 
 interface TableViewContentInnerProps {
-  sorting: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["sorting"];
-  columnResizing: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["columnResizing"];
-  columnSizing: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["columnSizing"];
+  sorting: ReturnType<TableInstance["atoms"]["sorting"]["get"]>;
+  columnResizing: ReturnType<TableInstance["atoms"]["columnResizing"]["get"]>;
+  columnSizing: ReturnType<TableInstance["atoms"]["columnSizing"]["get"]>;
 }
 
 function TableViewContentInner({

--- a/packages/table-view/src/table-contexts/table-view-provider.tsx
+++ b/packages/table-view/src/table-contexts/table-view-provider.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  use,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { createContext, use, useMemo, useRef } from "react";
 
 import {
   arrayToEntity,
@@ -55,23 +48,15 @@ export function TableViewWrapper<
   });
   const latestCtxRef = useRef(ctx);
   latestCtxRef.current = ctx;
-  const [committedResourceVersion, setCommittedResourceVersion] = useState(
-    ctx.resourceVersion,
-  );
-  useLayoutEffect(() => {
-    setCommittedResourceVersion(ctx.resourceVersion);
-  }, [ctx.resourceVersion]);
-  const contextValue = useMemo(() => {
-    void committedResourceVersion;
-    return {
+  const contextValue = useMemo(
+    () => ({
       get table() {
         return latestCtxRef.current.table;
       },
-      get resourceVersion() {
-        return latestCtxRef.current.resourceVersion;
-      },
-    } as TableViewCtx<TPlugins>;
-  }, [committedResourceVersion]);
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [ctx.table.options.columns, ctx.table.options.data],
+  );
 
   return (
     <TableViewContext value={contextValue}>

--- a/packages/table-view/src/table-contexts/table-view-reactivity.test.tsx
+++ b/packages/table-view/src/table-contexts/table-view-reactivity.test.tsx
@@ -224,6 +224,32 @@ describe("TableViewReactivity", () => {
     expect(onProbeRender).toHaveBeenCalledOnce();
   });
 
+  it("TableViewReactivity_ResourceUpdate_BroadcastsLatestTableOnce", async () => {
+    const onProbeRender = vi.fn();
+
+    function ContextProbe() {
+      useTableViewCtx();
+      return null;
+    }
+
+    renderTableView({
+      children: (
+        <>
+          <DataUpdateControls />
+          <Profiler id="context-probe" onRender={onProbeRender}>
+            <ContextProbe />
+          </Profiler>
+        </>
+      ),
+    });
+    expect(onProbeRender).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename first row" }));
+
+    expect(await screen.findByText("Renamed task")).toBeVisible();
+    expect(onProbeRender).toHaveBeenCalledTimes(2);
+  });
+
   it("TableViewReactivity_RowOpenAndModeChange_RendersSelectedRowView", async () => {
     const tableView = renderTableView({
       properties: [

--- a/packages/table-view/src/table-footer/table-footer.tsx
+++ b/packages/table-view/src/table-footer/table-footer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { flexRender } from "@tanstack/react-table";
 
 import { cn } from "@notion-kit/cn";
-import { CountMethod } from "@notion-kit/table-hook";
+import { CountMethod, type TableInstance } from "@notion-kit/table-hook";
 
 import { useTableViewCtx } from "@/table-contexts";
 
@@ -31,9 +31,7 @@ export function TableFooter() {
 function TableFooterContent({
   columnCounting,
 }: {
-  columnCounting: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["columnCounting"];
+  columnCounting: ReturnType<TableInstance["atoms"]["columnCounting"]["get"]>;
 }) {
   const { table } = useTableViewCtx();
 

--- a/packages/table-view/src/table-header/table-header-row.tsx
+++ b/packages/table-view/src/table-header/table-header-row.tsx
@@ -4,7 +4,7 @@ import { flexRender } from "@tanstack/react-table";
 import { cn } from "@notion-kit/cn";
 import { useIsMobile } from "@notion-kit/hooks";
 import { Icon } from "@notion-kit/icons";
-import { TableViewMenuPage } from "@notion-kit/table-hook";
+import { TableViewMenuPage, type TableInstance } from "@notion-kit/table-hook";
 import {
   Checkbox,
   DropdownMenu,
@@ -59,9 +59,7 @@ function TableHeaderRow() {
 function TableHeaderRowContent({
   tableGlobal,
 }: {
-  tableGlobal: ReturnType<
-    typeof useTableViewCtx
-  >["table"]["store"]["state"]["tableGlobal"];
+  tableGlobal: ReturnType<TableInstance["atoms"]["tableGlobal"]["get"]>;
 }) {
   const { table } = useTableViewCtx();
   const isMobile = useIsMobile();

--- a/packages/table-view/src/tools/sort-selector.tsx
+++ b/packages/table-view/src/tools/sort-selector.tsx
@@ -1,5 +1,3 @@
-import { useStore } from "@tanstack/react-store";
-
 import { Icon } from "@notion-kit/icons";
 import {
   Button,
@@ -15,49 +13,57 @@ import { SortMenu } from "../menus";
 export function SortSelector() {
   const { table } = useTableViewCtx();
 
-  const sorting = useStore(table.atoms.sorting, (state) => state);
-  const columnsInfo = useStore(table.atoms.columnsInfo, (state) => state);
-
-  const badgeDisplay = (() => {
-    const count = sorting.length;
-    if (count === 1) {
-      const sort = sorting[0]!;
-      return (
-        <>
-          {sort.desc ? (
-            <Icon.ArrowDown className="size-3.5" />
-          ) : (
-            <Icon.ArrowUp className="size-3.5" />
-          )}
-          {columnsInfo[sort.id]?.name}
-        </>
-      );
-    }
-    return (
-      <>
-        <Icon.ArrowUpDown className="size-4" />
-        {count} sorts
-      </>
-    );
-  })();
-
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          <Button
-            variant="soft-blue"
-            size="xs"
-            className="gap-1 rounded-full px-2 text-sm [&_svg]:fill-current"
-          >
-            {badgeDisplay}
-            <Icon.Chevron side="down" className="size-3" />
-          </Button>
-        }
-      />
-      <DropdownMenuContent className="w-80">
-        <SortMenu />
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <table.Subscribe
+      selector={(state) => ({
+        sorting: state.sorting,
+        columnsInfo: state.columnsInfo,
+      })}
+    >
+      {({ sorting, columnsInfo }) => {
+        const count = sorting.length;
+        const badgeDisplay = (() => {
+          if (count === 1) {
+            const sort = sorting[0]!;
+            return (
+              <>
+                {sort.desc ? (
+                  <Icon.ArrowDown className="size-3.5" />
+                ) : (
+                  <Icon.ArrowUp className="size-3.5" />
+                )}
+                {columnsInfo[sort.id]?.name}
+              </>
+            );
+          }
+          return (
+            <>
+              <Icon.ArrowUpDown className="size-4" />
+              {count} sorts
+            </>
+          );
+        })();
+
+        return (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  variant="soft-blue"
+                  size="xs"
+                  className="gap-1 rounded-full px-2 text-sm [&_svg]:fill-current"
+                >
+                  {badgeDisplay}
+                  <Icon.Chevron side="down" className="size-3" />
+                </Button>
+              }
+            />
+            <DropdownMenuContent className="w-80">
+              <SortMenu />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        );
+      }}
+    </table.Subscribe>
   );
 }

--- a/packages/table-view/src/tools/sort-selector.tsx
+++ b/packages/table-view/src/tools/sort-selector.tsx
@@ -1,3 +1,5 @@
+import { useStore } from "@tanstack/react-store";
+
 import { Icon } from "@notion-kit/icons";
 import {
   Button,
@@ -13,8 +15,10 @@ import { SortMenu } from "../menus";
 export function SortSelector() {
   const { table } = useTableViewCtx();
 
+  const sorting = useStore(table.atoms.sorting, (state) => state);
+  const columnsInfo = useStore(table.atoms.columnsInfo, (state) => state);
+
   const badgeDisplay = (() => {
-    const sorting = table.store.state.sorting;
     const count = sorting.length;
     if (count === 1) {
       const sort = sorting[0]!;
@@ -25,7 +29,7 @@ export function SortSelector() {
           ) : (
             <Icon.ArrowUp className="size-3.5" />
           )}
-          {table.getColumnInfo(sort.id).name}
+          {columnsInfo[sort.id]?.name}
         </>
       );
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1825,6 +1825,9 @@ importers:
       uuid:
         specifier: catalog:uuid
         version: 13.0.0
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@notion-kit/config':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,12 +164,6 @@ catalogs:
       specifier: ^1.120.5
       version: 1.168.6
   test:
-    '@ampproject/remapping':
-      specifier: ^2.3.0
-      version: 2.3.0
-    '@jridgewell/trace-mapping':
-      specifier: ^0.3.31
-      version: 0.3.31
     '@playwright/test':
       specifier: ^1.57.0
       version: 1.61.1
@@ -185,9 +179,6 @@ catalogs:
     '@vitest/ui':
       specifier: 4.1.8
       version: 4.1.8
-    monocart-coverage-reports:
-      specifier: ^2.11.5
-      version: 2.12.12
     msw:
       specifier: ^2.12.4
       version: 2.12.4
@@ -449,10 +440,10 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@ampproject/remapping':
-        specifier: catalog:test
+        specifier: ^2.3.0
         version: 2.3.0
       '@jridgewell/trace-mapping':
-        specifier: catalog:test
+        specifier: ^0.3.31
         version: 0.3.31
       '@notion-kit/eslint-config':
         specifier: workspace:*
@@ -491,7 +482,7 @@ importers:
         specifier: catalog:rtl
         version: 29.1.1(@noble/hashes@2.0.1)
       monocart-coverage-reports:
-        specifier: catalog:test
+        specifier: ^2.11.5
         version: 2.12.12
       prettier:
         specifier: 'catalog:'
@@ -1723,11 +1714,11 @@ importers:
         specifier: workspace:*
         version: link:../ui
       '@tanstack/react-table':
-        specifier: v9.0.0-beta.38
-        version: 9.0.0-beta.38(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: v9.0.0-beta.58
+        version: 9.0.0-beta.58(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/table-core':
-        specifier: 9.0.0-beta.38
-        version: 9.0.0-beta.38
+        specifier: 9.0.0-beta.58
+        version: 9.0.0-beta.58
       react:
         specifier: catalog:react19
         version: 19.2.3
@@ -1816,9 +1807,12 @@ importers:
       '@notion-kit/utils':
         specifier: workspace:*
         version: link:../utils
+      '@tanstack/react-store':
+        specifier: 0.11.0
+        version: 0.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-table':
-        specifier: v9.0.0-beta.38
-        version: 9.0.0-beta.38(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: v9.0.0-beta.58
+        version: 9.0.0-beta.58(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: catalog:react19
         version: 19.2.3
@@ -4110,19 +4104,11 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  '@jridgewell/gen-mapping@0.3.8':
-    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/remapping@2.3.5':
     resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
-
-  '@jridgewell/set-array@1.2.1':
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/source-map@0.3.11':
@@ -6209,8 +6195,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-table@9.0.0-beta.38':
-    resolution: {integrity: sha512-FKBVI9SpHqj+Jf8bdxLUNajnfbl3iYt0bhUPAN93kHH2L/XxHF41JPQDKbpqQC40WejbfJEHj4RIUirf3OAmVA==}
+  '@tanstack/react-table@9.0.0-beta.58':
+    resolution: {integrity: sha512-pvacQiA9pymAivt2dOOsOcnNEp5FMPvX2hjbnkWsh0lvlBtf6mh9bnZ7q14iAakGMiGs+o+/tbSr5jT19XfTgg==}
     engines: {node: '>=20'}
     peerDependencies:
       react: '>=18'
@@ -6286,8 +6272,8 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
-  '@tanstack/table-core@9.0.0-beta.38':
-    resolution: {integrity: sha512-Sr+jaFelc5CfkyYeVrPYYPL6PQJyP17p5WQHt+ip2vfKzxmhNLXD2mrI66wC8sNYfrhuWt6a5fMiSr4W3dXMDg==}
+  '@tanstack/table-core@9.0.0-beta.58':
+    resolution: {integrity: sha512-iP2N6AA4iU6NbLF/DOHoA/mJUDspz5cRIvPkqfTtuoURcjNp4MxbJPxTRUizuX8JejDL2PDfmLUMj3zU+znhyA==}
     engines: {node: '>=20'}
 
   '@tanstack/virtual-core@3.14.0':
@@ -11592,7 +11578,7 @@ snapshots:
     dependencies:
       '@babel/parser': 7.26.9
       '@babel/types': 7.29.7
-      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
@@ -13036,20 +13022,12 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@jridgewell/gen-mapping@0.3.8':
-    dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
-
   '@jridgewell/remapping@2.3.5':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
-
-  '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/source-map@0.3.11':
     dependencies:
@@ -15089,10 +15067,10 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/react-table@9.0.0-beta.38(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-table@9.0.0-beta.58(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/react-store': 0.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/table-core': 9.0.0-beta.38
+      '@tanstack/table-core': 9.0.0-beta.58
       react: 19.2.3
     transitivePeerDependencies:
       - react-dom
@@ -15187,7 +15165,7 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
-  '@tanstack/table-core@9.0.0-beta.38':
+  '@tanstack/table-core@9.0.0-beta.58':
     dependencies:
       '@tanstack/store': 0.11.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1807,9 +1807,6 @@ importers:
       '@notion-kit/utils':
         specifier: workspace:*
         version: link:../utils
-      '@tanstack/react-store':
-        specifier: 0.11.0
-        version: 0.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-table':
         specifier: v9.0.0-beta.58
         version: 9.0.0-beta.58(react-dom@19.2.3(react@19.2.3))(react@19.2.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,12 +27,9 @@ catalogs:
     next: ^16.1.0
     "@next/eslint-plugin-next": ^16.1.0
   test:
-    "@ampproject/remapping": ^2.3.0
-    "@jridgewell/trace-mapping": ^0.3.31
-    "@playwright/test": ^1.57.0
     msw: ^2.12.4
     msw-storybook-addon: ^2.0.6
-    monocart-coverage-reports: ^2.11.5
+    "@playwright/test": ^1.57.0
     playwright: ^1.57.0
     vitest: 4.1.8
     "@vitejs/plugin-react": 6.0.2


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrated table state to atom-based APIs and updated views/menus to subscribe to atoms (NK-45). Also upgraded `@tanstack/react-table` to v9.0.0-beta.58 and removed legacy resource/version helpers.

- **Refactors**
  - Replaced `store.state` reads with `atoms.*.get()` and introduced `<table.Subscribe>` across table-view (grouping, sorting, pinning, menu, layout).
  - Adopted `rowAggregationFeature` and `aggregateColumnValue` in the extended grouped row model; removed stale caches.
  - Removed `ResourceVersion` and related context wiring; simplified `use-table-view` and provider.
  - Tightened types using `TableInstance`; streamlined menus (props, sort, select-group, edit-group) and DnD flows; updated tests accordingly.
  - Switched to `zod/v4/mini` and adjusted number/date validations; prevented redundant DateTime blur updates.

- **Dependencies**
  - Bumped `@tanstack/react-table` and `@tanstack/table-core` to `v9.0.0-beta.58`.
  - Added `zod` to `table-view`; updated e2e devDeps (`@ampproject/remapping`, `@jridgewell/trace-mapping`, `monocart-coverage-reports`) and cleaned pnpm catalogs.

<sup>Written for commit 4b8b0fd82790e8f4c1a556a5036e688715ee3895. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/steeeee0223/notion-kit/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

