### PR TITLE
feat: dropdown menu checkbox -> radio

### DIFF
--- a/apps/docs/content/docs/components/dropdown-menu.mdx
+++ b/apps/docs/content/docs/components/dropdown-menu.mdx
@@ -26,6 +26,11 @@ links:
       <DropdownMenuItem />
     </DropdownMenuGroup>
     <DropdownMenuSeparator />
+    <DropdownMenuRadioGroup>
+      <DropdownMenuRadioItem />
+      <DropdownMenuRadioItem />
+    </DropdownMenuRadioGroup>
+    <DropdownMenuSeparator />
     <DropdownMenuSub>
       <DropdownMenuSubTrigger />
       <DropdownMenuContent>
@@ -82,6 +87,25 @@ Use `DropdownMenuCheckboxItem` for toggling options on and off.
 </DropdownMenu>`}
 />
 
+### Radio Items
+
+Use `DropdownMenuRadioGroup` and `DropdownMenuRadioItem` for mutually exclusive options.
+
+<ComponentPreview
+  name="dropdown-menu-radio"
+  preview={`<DropdownMenu>
+  <DropdownMenuTrigger render={<Button>Open</Button>} />
+  <DropdownMenuContent>
+    <DropdownMenuRadioGroup value={position} onValueChange={setPosition}>
+      <DropdownMenuLabel title="Position" />
+      <DropdownMenuRadioItem value="top" label="Top" />
+      <DropdownMenuRadioItem value="bottom" label="Bottom" />
+      <DropdownMenuRadioItem value="right" label="Right" />
+    </DropdownMenuRadioGroup>
+  </DropdownMenuContent>
+</DropdownMenu>`}
+/>
+
 ## API Reference
 
 ### DropdownMenu
@@ -125,6 +149,31 @@ A menu item that can be toggled on and off. Extends `DropdownMenuItem` props.
 | ----------------- | ---------------------------- | ------- | ---------------------------------------------- |
 | `checked`         | `boolean`                    | -       | Whether the item is checked.                   |
 | `onCheckedChange` | `(checked: boolean) => void` | -       | Handler called when the checked state changes. |
+
+### DropdownMenuRadioGroup
+
+Groups related radio items and manages their mutually exclusive value.
+
+| Prop            | Type                                 | Default | Description                                      |
+| --------------- | ------------------------------------ | ------- | ------------------------------------------------ |
+| `value`         | `any`                                | -       | The controlled value of the selected radio item. |
+| `defaultValue`  | `any`                                | -       | The initially selected value when uncontrolled.  |
+| `onValueChange` | `(value: any, eventDetails) => void` | -       | Handler called when the selected value changes.  |
+| `disabled`      | `boolean`                            | `false` | Whether the group ignores user interaction.      |
+
+### DropdownMenuRadioItem
+
+A menu item representing one value in a `DropdownMenuRadioGroup`. Extends the shared `MenuItem` visual props.
+
+| Prop           | Type                                                            | Default     | Description                                    |
+| -------------- | --------------------------------------------------------------- | ----------- | ---------------------------------------------- |
+| `value`        | `any`                                                           | -           | The value selected when the item is activated. |
+| `label`        | `string`                                                        | -           | The label text of the item.                    |
+| `icon`         | `React.ReactNode`                                               | -           | An optional leading icon.                      |
+| `desc`         | `string`                                                        | -           | An optional description below the label.       |
+| `variant`      | `"default" \| "secondary" \| "sidebar" \| "warning" \| "error"` | `"default"` | The visual style of the item.                  |
+| `disabled`     | `boolean`                                                       | `false`     | Whether the item ignores user interaction.     |
+| `closeOnClick` | `boolean`                                                       | `false`     | Whether selecting the item closes the menu.    |
 
 ### DropdownMenuLabel
 

--- a/apps/docs/src/__registry__/demos.tsx
+++ b/apps/docs/src/__registry__/demos.tsx
@@ -135,6 +135,12 @@ export const Index: Record<
       () => import("@notion-kit/registry/dropdown-menu-checkbox"),
     ),
   },
+  "dropdown-menu-radio": {
+    files: ["registry/src/dropdown-menu-radio/dropdown-menu-radio.tsx"],
+    component: React.lazy(
+      () => import("@notion-kit/registry/dropdown-menu-radio"),
+    ),
+  },
   "icon-block-emoji": {
     files: ["registry/src/icon-block-emoji/icon-block-emoji.tsx"],
     component: React.lazy(

--- a/apps/e2e/tests/controlled-resources.spec.ts
+++ b/apps/e2e/tests/controlled-resources.spec.ts
@@ -90,7 +90,7 @@ test("ControlledView_LayoutLockAndRowView_ParentStateStaysSynchronized", async (
   await expect(table.controlledState()).toContainText('"layout":"list"');
 
   await layout.item(/Open pages in/i).hover();
-  await page.getByRole("menuitemcheckbox", { name: "Center peek" }).click();
+  await page.getByRole("menuitemradio", { name: "Center peek" }).click();
   await expect(table.controlledState()).toContainText(
     '"type":"view.row_display.change"',
   );

--- a/apps/e2e/tests/layouts-and-row-views.spec.ts
+++ b/apps/e2e/tests/layouts-and-row-views.spec.ts
@@ -143,7 +143,7 @@ test("RowViews_SideCenterAndFull_UseConfiguredDisplayBoundary", async ({
 
   let layout = await (await table.openSettings()).openLayout();
   await layout.item(/Open pages in/i).hover();
-  await page.getByRole("menuitemcheckbox", { name: "Center peek" }).click();
+  await page.getByRole("menuitemradio", { name: "Center peek" }).click();
   await layout.close();
   await (await table.openRowActions("Omega")).openRow();
   await expect(page.getByRole("dialog", { name: "Omega" })).toBeVisible();
@@ -152,7 +152,7 @@ test("RowViews_SideCenterAndFull_UseConfiguredDisplayBoundary", async ({
 
   layout = await (await table.openSettings()).openLayout();
   await layout.item(/Open pages in/i).hover();
-  await page.getByRole("menuitemcheckbox", { name: "Full page" }).click();
+  await page.getByRole("menuitemradio", { name: "Full page" }).click();
   await layout.close();
   await (await table.openRowActions("Empty")).openRow();
   await expect(page).toHaveURL(/\/table-view\/rows\/row-empty$/);

--- a/apps/storybook/src/stories/ui/dropdown-menu.stories.tsx
+++ b/apps/storybook/src/stories/ui/dropdown-menu.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "storybook-react-rsbuild";
 
 import DropdownMenuDemo from "@notion-kit/registry/dropdown-menu";
 import DropdownMenuCheckboxes from "@notion-kit/registry/dropdown-menu-checkbox";
+import DropdownMenuRadio from "@notion-kit/registry/dropdown-menu-radio";
 
 import DropdownMenuInline from "./dropdown-menu-inline";
 
@@ -18,6 +19,9 @@ export const Example: Story = {
 };
 export const Checkboxes: Story = {
   render: () => <DropdownMenuCheckboxes />,
+};
+export const Radio: Story = {
+  render: () => <DropdownMenuRadio />,
 };
 export const InlineMenu: Story = {
   render: () => <DropdownMenuInline />,

--- a/packages/registry/src/dropdown-menu-radio/dropdown-menu-radio.tsx
+++ b/packages/registry/src/dropdown-menu-radio/dropdown-menu-radio.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@notion-kit/ui/primitives";
+
+export default function Demo() {
+  const [position, setPosition] = useState("top");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger render={<Button size="sm">Open</Button>} />
+      <DropdownMenuContent className="w-32">
+        <DropdownMenuRadioGroup
+          value={position}
+          onValueChange={(value: string) => setPosition(value)}
+        >
+          <DropdownMenuLabel title="Position" />
+          <DropdownMenuRadioItem value="top" label="Top" />
+          <DropdownMenuRadioItem value="bottom" label="Bottom" />
+          <DropdownMenuRadioItem value="right" label="Right" />
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/registry/src/dropdown-menu-radio/index.ts
+++ b/packages/registry/src/dropdown-menu-radio/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./dropdown-menu-radio";

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -25,6 +25,7 @@ export const registryIndex = [
   "cover-picker",
   "dropdown-menu",
   "dropdown-menu-checkbox",
+  "dropdown-menu-radio",
   "icon-block-emoji",
   "icon-block-lucide",
   "icon-block-sizes",

--- a/packages/table-view/src/__tests__/component-objects/layout-menu.ts
+++ b/packages/table-view/src/__tests__/component-objects/layout-menu.ts
@@ -24,11 +24,11 @@ export class LayoutMenuObject extends MenuSurfaceObject {
   }
 
   rowViewOption(name: RowView) {
-    return screen.getByRole("menuitemcheckbox", { name });
+    return screen.getByRole("menuitemradio", { name });
   }
 
   queryRowViewOption(name: RowView) {
-    return screen.queryByRole("menuitemcheckbox", { name });
+    return screen.queryByRole("menuitemradio", { name });
   }
 
   async selectLayout(name: Layout) {
@@ -37,7 +37,7 @@ export class LayoutMenuObject extends MenuSurfaceObject {
 
   async openRowViewOptions() {
     await this.user.hover(this.rowViewTrigger());
-    await screen.findByRole("menuitemcheckbox", { name: "Side peek" });
+    await screen.findByRole("menuitemradio", { name: "Side peek" });
   }
 
   async selectRowView(name: RowView) {

--- a/packages/table-view/src/__tests__/component-objects/number-config-menu.ts
+++ b/packages/table-view/src/__tests__/component-objects/number-config-menu.ts
@@ -44,8 +44,12 @@ export class NumberConfigMenuObject {
     return screen.getByRole("menuitemcheckbox", { name });
   }
 
-  queryCheckbox(name: string) {
-    return screen.queryByRole("menuitemcheckbox", { name });
+  radio(name: string) {
+    return screen.getByRole("menuitemradio", { name });
+  }
+
+  queryRadio(name: string) {
+    return screen.queryByRole("menuitemradio", { name });
   }
 
   async openSubmenu(name: string | RegExp) {
@@ -59,5 +63,9 @@ export class NumberConfigMenuObject {
 
   choose(name: string) {
     fireEvent.click(this.checkbox(name));
+  }
+
+  chooseRadio(name: string) {
+    fireEvent.click(this.radio(name));
   }
 }

--- a/packages/table-view/src/__tests__/component-objects/select-config-menu.ts
+++ b/packages/table-view/src/__tests__/component-objects/select-config-menu.ts
@@ -105,8 +105,7 @@ export class SelectConfigMenuObject {
     await this.user.hover(this.sortTrigger());
     const root = await findOpenMenu("select option sort menu", (menu) => {
       return (
-        within(menu).queryByRole("menuitemcheckbox", { name: "Manual" }) !==
-        null
+        within(menu).queryByRole("menuitemradio", { name: "Manual" }) !== null
       );
     });
     return new SelectConfigSortMenuObject(this.user, root);
@@ -146,7 +145,7 @@ export class SelectConfigSortMenuObject {
   ) {}
 
   item(name: Matcher) {
-    return within(this.root).getByRole("menuitemcheckbox", { name });
+    return within(this.root).getByRole("menuitemradio", { name });
   }
 
   choose(name: Matcher) {
@@ -165,7 +164,7 @@ export class SelectOptionConfigMenuObject {
   }
 
   color(name: Matcher) {
-    return within(this.root).getByRole("menuitemcheckbox", { name });
+    return within(this.root).getByRole("menuitemradio", { name });
   }
 
   colorsLabel() {

--- a/packages/table-view/src/menus/layout-menu.tsx
+++ b/packages/table-view/src/menus/layout-menu.tsx
@@ -9,9 +9,10 @@ import {
 } from "@notion-kit/table-hook";
 import {
   Button,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   MenuItemAction,
@@ -89,36 +90,38 @@ function RowViewMenu() {
             </MenuItemAction>
           </DropdownMenuSubTrigger>
           <DropdownMenuContent sideOffset={-4} className="w-64">
-            <DropdownMenuGroup>
+            <DropdownMenuRadioGroup
+              value={current}
+              onValueChange={(rowView: RowViewType) => {
+                if (rowView === current) return;
+                const actionId = v4();
+                table.setTableGlobalState(
+                  (v) => ({ ...v, rowView }),
+                  (previous, next) => ({
+                    id: actionId,
+                    type: "view.row_display.change",
+                    payload: {
+                      previousRowView: previous.rowView,
+                      nextRowView: next.rowView,
+                    },
+                  }),
+                );
+              }}
+            >
               {Object.entries(ROW_VIEW_OPTIONS).map(([value, option]) => {
                 const rowView = value as RowViewType;
                 return (
-                  <DropdownMenuCheckboxItem
+                  <DropdownMenuRadioItem
                     key={rowView}
+                    value={rowView}
                     closeOnClick={false}
                     icon={<RowViewIcon rowView={rowView} />}
                     label={option.label}
                     desc={option.desc}
-                    checked={rowView === current}
-                    onCheckedChange={(checked) => {
-                      if (!checked || rowView === current) return;
-                      const actionId = v4();
-                      table.setTableGlobalState(
-                        (v) => ({ ...v, rowView }),
-                        (previous, next) => ({
-                          id: actionId,
-                          type: "view.row_display.change",
-                          payload: {
-                            previousRowView: previous.rowView,
-                            nextRowView: next.rowView,
-                          },
-                        }),
-                      );
-                    }}
                   />
                 );
               })}
-            </DropdownMenuGroup>
+            </DropdownMenuRadioGroup>
           </DropdownMenuContent>
         </DropdownMenuSub>
       )}

--- a/packages/table-view/src/plugins/date/common/date-format-menu.tsx
+++ b/packages/table-view/src/plugins/date/common/date-format-menu.tsx
@@ -1,9 +1,9 @@
 import { Icon } from "@notion-kit/icons";
 import {
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuGroup,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
   MenuItem,
   MenuItemSelect,
@@ -47,16 +47,18 @@ export function DateFormatMenu({
         }
       />
       <DropdownMenuContent align="end" className="w-[180px]">
-        <DropdownMenuGroup>
+        <DropdownMenuRadioGroup
+          value={format}
+          onValueChange={(value: DateFormat) => onChange(value)}
+        >
           {options.map((option) => (
-            <DropdownMenuCheckboxItem
+            <DropdownMenuRadioItem
               key={option.value}
+              value={option.value}
               label={option.label}
-              checked={format === option.value}
-              onCheckedChange={() => onChange(option.value)}
             />
           ))}
-        </DropdownMenuGroup>
+        </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/table-view/src/plugins/date/common/time-format-menu.tsx
+++ b/packages/table-view/src/plugins/date/common/time-format-menu.tsx
@@ -1,9 +1,9 @@
 import { Icon } from "@notion-kit/icons";
 import {
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuGroup,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
   MenuItem,
   MenuItemSelect,
@@ -44,16 +44,18 @@ export function TimeFormatMenu({
         }
       />
       <DropdownMenuContent align="end" className="w-[180px]">
-        <DropdownMenuGroup>
+        <DropdownMenuRadioGroup
+          value={format}
+          onValueChange={(value: TimeFormat) => onChange(value)}
+        >
           {options.map((option) => (
-            <DropdownMenuCheckboxItem
+            <DropdownMenuRadioItem
               key={option.value}
+              value={option.value}
               label={option.label}
-              checked={format === option.value}
-              onCheckedChange={() => onChange(option.value)}
             />
           ))}
-        </DropdownMenuGroup>
+        </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/table-view/src/plugins/date/date-cell/date-cell.test.tsx
+++ b/packages/table-view/src/plugins/date/date-cell/date-cell.test.tsx
@@ -69,7 +69,7 @@ it("DatePicker_EndTimeFormatsAndClear_UpdateCanonicalState", async () => {
 
   await user.click(screen.getByRole("menuitem", { name: /Date format/i }));
   await user.click(
-    await screen.findByRole("menuitemcheckbox", { name: "Short date" }),
+    await screen.findByRole("menuitemradio", { name: "Short date" }),
   );
   expect(screen.getByTestId("date-config")).toHaveTextContent(
     '"dateFormat":"short"',
@@ -77,7 +77,7 @@ it("DatePicker_EndTimeFormatsAndClear_UpdateCanonicalState", async () => {
 
   await user.click(screen.getByRole("menuitem", { name: /Time format/i }));
   await user.click(
-    await screen.findByRole("menuitemcheckbox", { name: "12 hour" }),
+    await screen.findByRole("menuitemradio", { name: "12 hour" }),
   );
   expect(screen.getByTestId("date-config")).toHaveTextContent(
     '"timeFormat":"12-hour"',

--- a/packages/table-view/src/plugins/number/number-config-menu/format-menu.tsx
+++ b/packages/table-view/src/plugins/number/number-config-menu/format-menu.tsx
@@ -1,7 +1,7 @@
 import {
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuGroup,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
 } from "@notion-kit/ui/primitives";
@@ -29,17 +29,19 @@ export function FormatMenu({ format, onUpdate }: FormatMenuProps) {
         </div>
       </DropdownMenuSubTrigger>
       <DropdownMenuContent sideOffset={-4} className="w-48">
-        <DropdownMenuGroup>
+        <DropdownMenuRadioGroup
+          value={format}
+          onValueChange={(value: NumberFormat) => onUpdate(value)}
+        >
           {options.map((option) => (
-            <DropdownMenuCheckboxItem
+            <DropdownMenuRadioItem
               key={option.value}
+              value={option.value}
               closeOnClick={false}
               label={option.label}
-              checked={format === option.value}
-              onCheckedChange={() => onUpdate(option.value)}
             />
           ))}
-        </DropdownMenuGroup>
+        </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenuSub>
   );

--- a/packages/table-view/src/plugins/number/number-config-menu/number-config-menu.test.tsx
+++ b/packages/table-view/src/plugins/number/number-config-menu/number-config-menu.test.tsx
@@ -65,7 +65,7 @@ describe("FormatMenu", () => {
     );
     await menu.openSubmenu(/Number format/i);
 
-    menu.choose("Currency");
+    menu.chooseRadio("Currency");
     expect(onChange).toHaveBeenCalledOnce();
     expect(onChange).toHaveBeenCalledWith("currency");
     expect(menu.item(/Number format/i)).toBeInTheDocument();
@@ -80,7 +80,7 @@ describe("RoundingMenu", () => {
     );
     await menu.openSubmenu(/Decimal places/i);
 
-    menu.choose("2");
+    menu.chooseRadio("2");
     expect(onChange).toHaveBeenCalledOnce();
     expect(onChange).toHaveBeenCalledWith("2");
     expect(menu.item(/Decimal places/i)).toBeInTheDocument();

--- a/packages/table-view/src/plugins/number/number-config-menu/rounding-menu.tsx
+++ b/packages/table-view/src/plugins/number/number-config-menu/rounding-menu.tsx
@@ -1,7 +1,7 @@
 import {
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuGroup,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
 } from "@notion-kit/ui/primitives";
@@ -32,17 +32,19 @@ export function RoundingMenu({ round, onUpdate }: RoundingMenuProps) {
         </div>
       </DropdownMenuSubTrigger>
       <DropdownMenuContent sideOffset={-4}>
-        <DropdownMenuGroup>
+        <DropdownMenuRadioGroup
+          value={round}
+          onValueChange={(value: NumberRound) => onUpdate(value)}
+        >
           {options.map((option) => (
-            <DropdownMenuCheckboxItem
+            <DropdownMenuRadioItem
               key={option.value}
+              value={option.value}
               closeOnClick={false}
               label={option.label}
-              checked={round === option.value}
-              onCheckedChange={() => onUpdate(option.value)}
             />
           ))}
-        </DropdownMenuGroup>
+        </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenuSub>
   );

--- a/packages/table-view/src/plugins/select/select-config-menu/select-config-menu.tsx
+++ b/packages/table-view/src/plugins/select/select-config-menu/select-config-menu.tsx
@@ -4,10 +4,11 @@ import { useInputField } from "@notion-kit/hooks";
 import { Icon } from "@notion-kit/icons";
 import {
   Button,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   getSortableItemsAfterDrag,
@@ -102,16 +103,18 @@ export function SelectConfigMenuContent({
             className="w-[250px]"
             finalFocus={false}
           >
-            <DropdownMenuGroup>
+            <DropdownMenuRadioGroup
+              value={config.sort}
+              onValueChange={(value: SelectSort) => updateSort(value)}
+            >
               {sortOptions.map((option) => (
-                <DropdownMenuCheckboxItem
+                <DropdownMenuRadioItem
                   key={option.value}
+                  value={option.value}
                   label={option.label}
-                  checked={config.sort === option.value}
-                  onCheckedChange={() => updateSort(option.value)}
                 />
               ))}
-            </DropdownMenuGroup>
+            </DropdownMenuRadioGroup>
           </DropdownMenuContent>
         </DropdownMenuSub>
       </DropdownMenuGroup>

--- a/packages/table-view/src/plugins/select/select-option-menu/select-option-menu.tsx
+++ b/packages/table-view/src/plugins/select/select-option-menu/select-option-menu.tsx
@@ -1,10 +1,11 @@
 import { Icon } from "@notion-kit/icons";
 import {
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
 } from "@notion-kit/ui/primitives";
 import { COLOR, type Color } from "@notion-kit/utils";
@@ -51,18 +52,20 @@ export function SelectOptionMenu({
         />
       </DropdownMenuGroup>
       <DropdownMenuSeparator />
-      <DropdownMenuGroup>
+      <DropdownMenuRadioGroup
+        value={option.color}
+        onValueChange={(color: Color) => onUpdate({ color })}
+      >
         <DropdownMenuLabel title="Colors" />
         {Object.entries(COLOR).map(([key, color]) => (
-          <DropdownMenuCheckboxItem
+          <DropdownMenuRadioItem
             key={key}
+            value={key}
             icon={<ColorIcon color={color.rgba} />}
             label={color.name}
-            checked={option.color === key}
-            onCheckedChange={() => onUpdate({ color: key as Color })}
           />
         ))}
-      </DropdownMenuGroup>
+      </DropdownMenuRadioGroup>
     </DropdownMenuContent>
   );
 }

--- a/packages/table-view/src/row-view/view-nav.tsx
+++ b/packages/table-view/src/row-view/view-nav.tsx
@@ -6,9 +6,9 @@ import { ROW_VIEW_OPTIONS, RowViewType } from "@notion-kit/table-hook";
 import {
   Button,
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuGroup,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
   Separator,
   TooltipDescription,
@@ -106,37 +106,39 @@ export function ViewNav({ rowId }: ViewNavProps) {
             />
           </TooltipPreset>
           <DropdownMenuContent className="z-999 w-52">
-            <DropdownMenuGroup>
+            <DropdownMenuRadioGroup
+              value={rowView}
+              onValueChange={(view: RowViewType) => {
+                if (rowView === view) return;
+                const actionId = v4();
+                table.setTableGlobalState(
+                  (v) => ({
+                    ...v,
+                    rowView: view,
+                  }),
+                  (previous, next) => ({
+                    id: actionId,
+                    type: "view.row_display.change",
+                    payload: {
+                      previousRowView: previous.rowView,
+                      nextRowView: next.rowView,
+                    },
+                  }),
+                );
+              }}
+            >
               {Object.entries(ROW_VIEW_OPTIONS).map(([key, option]) => {
                 const view = key as RowViewType;
                 return (
-                  <DropdownMenuCheckboxItem
+                  <DropdownMenuRadioItem
                     key={view}
+                    value={view}
                     icon={<RowViewIcon rowView={view} />}
                     label={option.label}
-                    checked={rowView === view}
-                    onCheckedChange={(checked) => {
-                      if (!checked || rowView === view) return;
-                      const actionId = v4();
-                      table.setTableGlobalState(
-                        (v) => ({
-                          ...v,
-                          rowView: view,
-                        }),
-                        (previous, next) => ({
-                          id: actionId,
-                          type: "view.row_display.change",
-                          payload: {
-                            previousRowView: previous.rowView,
-                            nextRowView: next.rowView,
-                          },
-                        }),
-                      );
-                    }}
                   />
                 );
               })}
-            </DropdownMenuGroup>
+            </DropdownMenuRadioGroup>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/packages/table-view/src/table-contexts/table-view-reactivity.test.tsx
+++ b/packages/table-view/src/table-contexts/table-view-reactivity.test.tsx
@@ -301,7 +301,7 @@ describe("TableViewReactivity", () => {
     expect(trigger).not.toBeNull();
     fireEvent.click(trigger!);
     fireEvent.click(
-      await screen.findByRole("menuitemcheckbox", { name: "Side peek" }),
+      await screen.findByRole("menuitemradio", { name: "Side peek" }),
     );
 
     expect(onViewChange).not.toHaveBeenCalled();
@@ -332,7 +332,7 @@ describe("TableViewReactivity", () => {
       dialog.querySelector<HTMLElement>('[aria-haspopup="menu"]')!,
     );
     fireEvent.click(
-      await screen.findByRole("menuitemcheckbox", { name: "Center peek" }),
+      await screen.findByRole("menuitemradio", { name: "Center peek" }),
     );
 
     await waitFor(() => expect(onViewChange).toHaveBeenCalledOnce());

--- a/packages/ui/src/primitives/dropdown-menu.tsx
+++ b/packages/ui/src/primitives/dropdown-menu.tsx
@@ -44,7 +44,7 @@ function DropdownMenuSub({ ...props }: Menu.SubmenuRoot.Props) {
 
 type MenuItemVisualProps = Pick<
   React.ComponentProps<typeof MenuItem>,
-  "className" | "variant" | "desc"
+  "className" | "variant" | "icon" | "desc"
 >;
 
 interface DropdownMenuSubTriggerProps
@@ -53,7 +53,6 @@ interface DropdownMenuSubTriggerProps
       "children" | "className" | "label" | "render"
     >,
     MenuItemVisualProps {
-  icon?: React.ReactNode;
   label?: React.ReactNode;
   children?: React.ReactNode;
   chevron?: boolean;
@@ -136,9 +135,7 @@ function DropdownMenuContent({
 interface DropdownMenuItemProps
   extends Omit<Menu.Item.Props, "className" | "label" | "render">,
     MenuItemVisualProps {
-  icon?: React.ReactNode;
   label?: React.ReactNode;
-  children?: React.ReactNode;
 }
 
 function DropdownMenuItem({
@@ -171,15 +168,10 @@ function DropdownMenuItem({
 }
 
 interface DropdownMenuCheckboxItemProps
-  extends Omit<
-      Menu.CheckboxItem.Props,
-      "children" | "className" | "label" | "render"
-    >,
+  extends Omit<Menu.CheckboxItem.Props, "className" | "label" | "render">,
     MenuItemVisualProps {
-  icon?: React.ReactNode;
   label?: React.ReactNode;
   checkType?: "check" | "switch";
-  children?: React.ReactNode;
 }
 
 function DropdownMenuCheckboxItem({
@@ -233,31 +225,37 @@ function DropdownMenuRadioGroup({ ...props }: Menu.RadioGroup.Props) {
   );
 }
 
-/**
- * @todo this is currently unused, update the style
- */
+interface DropdownMenuRadioItemProps
+  extends Omit<Menu.RadioItem.Props, "className" | "render">,
+    MenuItemVisualProps {}
+
 function DropdownMenuRadioItem({
   className,
+  variant,
+  icon,
+  label,
+  desc,
   children,
   ...props
-}: Menu.RadioItem.Props) {
+}: DropdownMenuRadioItemProps) {
   return (
     <Menu.RadioItem
       data-slot="dropdown-menu-radio-item"
-      className={cn(
-        "relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50",
-        className,
-      )}
+      label={label}
+      render={
+        <MenuItem
+          className={className}
+          variant={variant}
+          icon={icon}
+          label={label}
+          desc={desc}
+        >
+          {children}
+          <Menu.RadioItemIndicator render={<MenuItemCheck />} />
+        </MenuItem>
+      }
       {...props}
-    >
-      <span className="absolute left-2 flex size-3.5 items-center justify-center">
-        {/* FIXME */}
-        <Menu.RadioItemIndicator className="grid size-full place-items-center">
-          <span className="size-2 rounded-full bg-white" />
-        </Menu.RadioItemIndicator>
-      </span>
-      {children}
-    </Menu.RadioItem>
+    />
   );
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched mutually exclusive dropdown options from checkboxes to radio groups across Table View and the UI primitives. This improves accessibility (correct ARIA roles), simplifies state handling, and updates docs and Storybook.

- New Features
  - Added `DropdownMenuRadioGroup` and enhanced `DropdownMenuRadioItem` in `@notion-kit/ui/primitives` (now uses shared `MenuItem` visuals and supports `icon`/`desc`).
  - Migrated Table View menus to radio groups: row view switcher, date/time formats, number format/rounding, and select sort/color menus.
  - Updated docs with a Radio Items section and a new demo in `@notion-kit/registry` + Storybook story.
  - Updated e2e/unit tests to target `menuitemradio`.

- Migration
  - For mutually exclusive choices, wrap items in `DropdownMenuRadioGroup` and use `DropdownMenuRadioItem`.
  - Replace `checked`/`onCheckedChange` with `value` on items and `value`/`onValueChange` on the group.
  - Update tests to query/click `role="menuitemradio"` instead of `menuitemcheckbox`.

<sup>Written for commit 8bed04e5cc23a9896855afb03610572bd9139116. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/steeeee0223/notion-kit/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

