### PR TITLE
feat: table v9, and e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,43 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./tooling/github/setup
+        with:
+          base: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.before || github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/main' }}
+          head: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+
+      - name: Check whether E2E is affected
+        id: affected
+        shell: bash
+        run: |
+          if pnpm exec turbo query affected \
+            --packages @notion-kit/e2e \
+            --base "$TURBO_SCM_BASE" \
+            --head "$TURBO_SCM_HEAD" \
+            --exit-code; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            status=$?
+            if [[ "$status" -ne 1 ]]; then
+              exit "$status"
+            fi
+
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Chromium
+        if: steps.affected.outputs.run == 'true'
+        run: pnpm --filter @notion-kit/e2e exec playwright install --with-deps chromium
+
+      - name: E2E test
+        if: steps.affected.outputs.run == 'true'
+        run: pnpm --filter @notion-kit/e2e test:e2e

--- a/apps/e2e/tests/drag-and-drop.spec.ts
+++ b/apps/e2e/tests/drag-and-drop.spec.ts
@@ -9,6 +9,7 @@ async function dragWithPointer(
   target: Locator,
   targetEdge: "center" | "after" = "center",
 ) {
+  await source.scrollIntoViewIfNeeded();
   const sourceBox = await source.boundingBox();
   const targetBox = await target.boundingBox();
   expect(sourceBox).not.toBeNull();

--- a/packages/table-hook/package.json
+++ b/packages/table-hook/package.json
@@ -40,8 +40,8 @@
     "@dnd-kit/react": "catalog:ui",
     "@notion-kit/cn": "workspace:*",
     "@notion-kit/ui": "workspace:*",
-    "@tanstack/react-table": "v9.0.0-beta.58",
-    "@tanstack/table-core": "9.0.0-beta.58",
+    "@tanstack/react-table": "9.0.0",
+    "@tanstack/table-core": "9.0.0",
     "uuid": "catalog:uuid",
     "zod": "catalog:"
   },

--- a/packages/table-hook/src/features/row-selection.ts
+++ b/packages/table-hook/src/features/row-selection.ts
@@ -40,22 +40,4 @@ export const InternalRowSelectionFeature: typeof rowSelectionFeature = {
       },
     };
   },
-  constructTableAPIs: (_table) => {
-    rowSelectionFeature.constructTableAPIs?.(_table);
-
-    const table = _table as unknown as _TableInstance;
-    const setOptions = table.setOptions.bind(table);
-    table.setOptions = (updater) => {
-      table._reactivity.batch(() => {
-        setOptions(updater);
-        table.baseAtoms.rowSelection.set((selection) =>
-          table.atoms.tableGlobal.get().locked
-            ? Object.keys(selection).length === 0
-              ? selection
-              : {}
-            : pruneRowSelection(selection, table.options.data),
-        );
-      });
-    };
-  },
 };

--- a/packages/table-hook/src/table-contexts/use-table-view.tsx
+++ b/packages/table-hook/src/table-contexts/use-table-view.tsx
@@ -7,6 +7,7 @@ import {
 
 import { DEFAULT_FEATURES, type TableFeatures } from "@/features";
 import type { TableViewState } from "@/features/menu";
+import { pruneRowSelection } from "@/features/row-selection";
 import type { ColumnDefs, ColumnInfo, Row } from "@/lib/types";
 import { type Entity } from "@/lib/utils";
 import { resolveGroupingMethod, resolveSortingMethod } from "@/methods";
@@ -289,6 +290,14 @@ export function useTableView<TPlugins extends CellPlugin[]>(
       getRowUrl,
     },
     () => null,
+  );
+
+  table.baseAtoms.rowSelection.set((selection) =>
+    tableGlobalState.locked
+      ? Object.keys(selection).length === 0
+        ? selection
+        : {}
+      : pruneRowSelection(selection, dataEntity),
   );
 
   return useMemo(() => ({ table }), [table]);

--- a/packages/table-view/package.json
+++ b/packages/table-view/package.json
@@ -48,7 +48,7 @@
     "@notion-kit/table-hook": "workspace:*",
     "@notion-kit/ui": "workspace:*",
     "@notion-kit/utils": "workspace:*",
-    "@tanstack/react-table": "v9.0.0-beta.58",
+    "@tanstack/react-table": "9.0.0",
     "react-hotkeys-hook": "catalog:ui",
     "uuid": "catalog:uuid",
     "zod": "catalog:"

--- a/packages/table-view/src/list-view/list-row.tsx
+++ b/packages/table-view/src/list-view/list-row.tsx
@@ -39,7 +39,7 @@ export function ListRow({ rowId }: ListRowProps) {
           <div className="relative flex items-center">
             {!locked && (
               <RowActionGroup
-                className="absolute -left-16"
+                className="absolute -left-20"
                 isMobile={isMobile}
                 row={row}
                 onAddNext={addNextRow}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1714,11 +1714,11 @@ importers:
         specifier: workspace:*
         version: link:../ui
       '@tanstack/react-table':
-        specifier: v9.0.0-beta.58
-        version: 9.0.0-beta.58(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 9.0.0
+        version: 9.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/table-core':
-        specifier: 9.0.0-beta.58
-        version: 9.0.0-beta.58
+        specifier: 9.0.0
+        version: 9.0.0
       react:
         specifier: catalog:react19
         version: 19.2.3
@@ -1811,8 +1811,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       '@tanstack/react-table':
-        specifier: v9.0.0-beta.58
-        version: 9.0.0-beta.58(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 9.0.0
+        version: 9.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: catalog:react19
         version: 19.2.3
@@ -6198,8 +6198,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-table@9.0.0-beta.58':
-    resolution: {integrity: sha512-pvacQiA9pymAivt2dOOsOcnNEp5FMPvX2hjbnkWsh0lvlBtf6mh9bnZ7q14iAakGMiGs+o+/tbSr5jT19XfTgg==}
+  '@tanstack/react-table@9.0.0':
+    resolution: {integrity: sha512-Q/Z49MQcdMwge67U+LTjSEQJCnQE9/tNWK5IpiYex9JFDzfjNkLIi7yzGA4dfW4UpuMBrtqbSnSzn7oPr60T+w==}
     engines: {node: '>=20'}
     peerDependencies:
       react: '>=18'
@@ -6275,8 +6275,8 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
-  '@tanstack/table-core@9.0.0-beta.58':
-    resolution: {integrity: sha512-iP2N6AA4iU6NbLF/DOHoA/mJUDspz5cRIvPkqfTtuoURcjNp4MxbJPxTRUizuX8JejDL2PDfmLUMj3zU+znhyA==}
+  '@tanstack/table-core@9.0.0':
+    resolution: {integrity: sha512-IyKCc4D7d/+I9euQntlVDQ7lnilmFRKpIROBeI5/866adFy+65xWvCFPz76NZ5j2lXe/RFDvFVV7bfETmwHEMA==}
     engines: {node: '>=20'}
 
   '@tanstack/virtual-core@3.14.0':
@@ -15070,10 +15070,10 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/react-table@9.0.0-beta.58(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-table@9.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/react-store': 0.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/table-core': 9.0.0-beta.58
+      '@tanstack/table-core': 9.0.0
       react: 19.2.3
     transitivePeerDependencies:
       - react-dom
@@ -15168,7 +15168,7 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
-  '@tanstack/table-core@9.0.0-beta.58':
+  '@tanstack/table-core@9.0.0':
     dependencies:
       '@tanstack/store': 0.11.0
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgraded `@tanstack/react-table`/`@tanstack/table-core` to 9.0.0 and added an `e2e` CI job that runs Playwright Chromium only when `@notion-kit/e2e` is affected. Stabilized the drag-and-drop test, fixed row selection pruning/lock handling for v9, and tweaked row action spacing.

- **New Features**
  - Add `e2e` GitHub Actions job with Turbo affected check to conditionally run `@notion-kit/e2e` Playwright tests.
  - Install Chromium only when needed; runs `pnpm --filter @notion-kit/e2e test:e2e`.

- **Dependencies**
  - Bump `@tanstack/react-table` to `9.0.0` in `@notion-kit/table-hook` and `@notion-kit/table-view`.
  - Bump `@tanstack/table-core` to `9.0.0`; update `pnpm-lock.yaml`.

<sup>Written for commit 172a422c8b8860823e785e58b43013f3552f816c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/steeeee0223/notion-kit/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

