### PR TITLE
🚀 `1.1.0` release

### DIFF
--- a/.github/workflows/bootstrap-npm-package.yml
+++ b/.github/workflows/bootstrap-npm-package.yml
@@ -133,4 +133,5 @@ jobs:
             exit 1
           fi
 
+          npm config set '//registry.npmjs.org/:_authToken' "$NODE_AUTH_TOKEN"
           npm publish "$TARBALL" --access public --tag "$NPM_DIST_TAG"

--- a/.github/workflows/bootstrap-npm-package.yml
+++ b/.github/workflows/bootstrap-npm-package.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Build package and workspace dependencies
         env:
           PACKAGE_NAME: ${{ steps.package.outputs.name }}
-        run: pnpm exec turbo run build --filter="...${PACKAGE_NAME}"
+        run: pnpm build --filter=${PACKAGE_NAME}
 
       - name: Pack package
         id: pack

--- a/apps/auth-server/package.json
+++ b/apps/auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/auth-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/docs/content/docs/blocks/table-view/cell-plugins.mdx
+++ b/apps/docs/content/docs/blocks/table-view/cell-plugins.mdx
@@ -1,93 +1,54 @@
 ---
 title: Cell Plugins
-description: Cell plugins define how specific properties behave and render in the Notion database.
+description: Define how a table property stores, displays, edits, and groups its values.
 ---
 
-A `CellPlugin` is a generic interface that accepts four type parameters:
+A `CellPlugin<Key, Data, Config>` describes one property type. `Key` is its
+unique identifier, `Data` is the stored cell value, and `Config` is the
+property-level configuration.
 
-- `Key`: The unique identifier for the plugin.
-- `Data`: The data type stored in the cell.
-- `Config` (optional): The configuration type for the plugin.
+## Plugin definition
 
-## API Reference
+| Field         | Description                                                                                |
+| ------------- | ------------------------------------------------------------------------------------------ |
+| `id`          | Unique property type identifier.                                                           |
+| `meta`        | Name, description, and icon displayed in the property-type menu.                           |
+| `default`     | Default name, icon, configuration, width, and data for newly created properties and cells. |
+| `fromValue`   | Converts a comparable value into the plugin's cell data.                                   |
+| `toValue`     | Converts cell data into a string, number, boolean, or `null` value for sorting.            |
+| `toTextValue` | Converts cell data into text for compact display or export.                                |
 
-### CellPlugin
+## Optional capabilities
 
-| Prop                  | Type                                                              | Description                                                                                                              |
-| --------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `id`\*                | `Key`                                                             | Unique identifier of the plugin.                                                                                         |
-| `meta.name`\*         | `string`                                                          | The name of the plugin. This will be displayed in the UI.                                                                |
-| `meta.desc`\*         | `string`                                                          | The description of the plugin. This will be displayed in the UI.                                                         |
-| `meta.icon`\*         | `React.ReactNode`                                                 | The icon of the plugin. This will be displayed in the UI.                                                                |
-| `default.name`\*      | `string`                                                          | Default name used when a new column of this plugin is created.                                                           |
-| `default.icon`\*      | `React.ReactNode`                                                 | Default icon used when a new column of this plugin is created.                                                           |
-| `default.config`\*    | `Config`                                                          | Default config used when a new column of this plugin is created.                                                         |
-| `default.width`       | `number`                                                          | Default width used when a new column of this plugin is created.                                                          |
-| `default.data`\*      | `Data`                                                            | Default data used when a new cell of this plugin is created.                                                             |
-| `fromValue`\*         | `(value: ComparableValue, config: Config) => Data`                | Converts value to the plugin's data type.                                                                                |
-| `toValue`\*           | `(data: Data, row: Row) => ComparableValue`                       | Converts the plugin's data type to a value. This is useful for sorting a column.                                         |
-| `toGroupValue`        | `(data: Data, row: Row) => ComparableValue`                       | Converts the plugin's data type to a grouping value. This is useful for grouping by a column.                            |
-| `toTextValue`\*       | `(data: Data, row: Row) => string`                                | Converts the plugin's data type to a string value. This is useful for displaying/exporting the data in a compact format. |
-| `transferConfig`      | `(column: ColumnInfo<TPlugin>, data: Row<TPlugin[]>[]) => Config` | Converts the given column and rows data to this plugin configuration. This is useful for changing column types.          |
-| `compare`\*           | `(rowA: Row, rowB: Row, colId: string) => number`                 | Compares two rows based on the plugin's data type. This is useful for sorting a column.                                  |
-| `renderCell`\*        | `(props: CellProps<Data, Config>) => React.ReactNode`             | Renders the cell for this plugin. This is where you define how the cell should look and behave in the UI.                |
-| `renderConfigMenu`    | `(props: ConfigMenuProps<Config>) => React.ReactNode`             | Renders the configuration menu for this plugin. This is where you define how the column configuration should look.       |
-| `renderGroupingValue` | `(props: GroupingValueProps) => React.ReactNode`                  | Renders the grouping value for this plugin. This is where you define how the grouping value should look.                 |
+| Field             | Description                                                                       |
+| ----------------- | --------------------------------------------------------------------------------- |
+| `toGroupValue`    | Supplies a value for grouping. Falls back to `toValue`.                           |
+| `sorting`         | Declares the sorting methods available for the property.                          |
+| `grouping`        | Declares the grouping methods available for the property.                         |
+| `counting`        | Declares footer calculations for the property.                                    |
+| `compare`         | Legacy row comparator for the property. Prefer `sorting.methods` for new plugins. |
+| `transferConfig`  | Converts an existing property configuration when its type changes.                |
+| `disableBulkEdit` | Excludes an editor-capable plugin from the bulk-edit bar.                         |
 
-### CellProps
+## Rendering
 
-| Prop             | Type                                           | Description                                                                                                          |
-| ---------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `propId`\*       | `string`                                       | The ID of the column this cell belongs to. This is useful for identifying the column in the table.                   |
-| `row`\*          | [`Row`](/docs/objects/database-properties#row) | The row this cell belongs to. This is useful for identifying the row in the table.                                   |
-| `data`\*         | `Data`                                         | The data of the cell. This is the value stored in the cell.                                                          |
-| `config`\*       | `Config`                                       | The configuration of the cell. This can be used to customize the cell's behavior.                                    |
-| `wrapped`        | `boolean`                                      | Whether the cell should be wrapped. This is useful for long text values that need to be displayed in multiple lines. |
-| `onChange`\*     | `OnChangeFn<Data>`                             | A callback function that is called when the cell data changes.                                                       |
-| `onConfigChange` | `OnChangeFn<Config>`                           | A callback function that is called when the column configuration changes.                                            |
+| Field                 | Description                                                                                                                                                                                                                                           |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `renderCellValue`     | **Required.** Renders the cell's read-only value. It receives `CellValueProps`, including the value, property configuration, row, layout, and disabled state.                                                                                         |
+| `renderCellEditor`    | Renders the editing UI and returns either an inline or popover editor. It receives `CellEditorProps`, including `onChange`, `onCancel`, and a `scope` for a single cell or selected rows. Plugins with this capability are eligible for bulk editing. |
+| `renderConfigMenu`    | Renders the property configuration UI.                                                                                                                                                                                                                |
+| `renderGroupingValue` | Renders a group label.                                                                                                                                                                                                                                |
 
-### ConfigMenuProps
+## Types
 
-| Prop         | Type                 | Description                                                                                                      |
-| ------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `propId`\*   | `string`             | The ID of the column this configuration menu belongs to. This is useful for identifying the column in the table. |
-| `config`\*   | `Config`             | The configuration of the column. This can be used to customize the column's behavior.                            |
-| `onChange`\* | `OnChangeFn<Config>` | A callback function that is called when the column configuration changes.                                        |
-
-### GroupingValueProps
-
-| Prop      | Type              | Description         |
-| --------- | ----------------- | ------------------- |
-| `value`\* | `ComparableValue` | The grouping value. |
-| `table`\* | `Table<Row>`      | The table instance. |
-
-### TableDataAtom
-
-A `TableDataAtom` represents the atom state of a table, including its column informations and row data.
-
-| Prop           | Type                                                                         | Default | Description                           |
-| -------------- | ---------------------------------------------------------------------------- | ------- | ------------------------------------- |
-| `properties`\* | [`Record<string, ColumnInfo>`](/docs/objects/database-properties#columninfo) | -       | The column informations of the table. |
-| `data`\*       | [`Row[]`](/docs/objects/database-properties#row)                             | -       | The rows of the table.                |
-
-### Type Inference Utilities
-
-| Type                    | Description                                      |
-| ----------------------- | ------------------------------------------------ |
-| `InferKey<TPlugin>`     | Infers the plugin ID from `CellPlugin`.          |
-| `InferData<TPlugin>`    | Infers the cell data type.                       |
-| `InferConfig<TPlugin>`  | Infers the column config type.                   |
-| `InferPlugin<TPlugins>` | Merges plugin types into a unified `CellPlugin`. |
-
----
-
-## What's Next?
-
-You can define plugins, columns, and rows in a flexible and strongly-typed way using these abstractions.
+| Type                                                  | Description                                                            |
+| ----------------------------------------------------- | ---------------------------------------------------------------------- |
+| `CellValueProps<Data, Config>`                        | Props for a cell value renderer.                                       |
+| `CellEditorProps<Data, Config>`                       | Props for a cell editor, including its update callback and edit scope. |
+| `ConfigMenuProps<Config>`                             | Props for a property configuration menu.                               |
+| `CellEditorResult`                                    | The inline or popover editor returned by `renderCellEditor`.           |
+| `InferKey`, `InferData`, `InferConfig`, `InferPlugin` | Utility types for deriving plugin types.                               |
 
 <Cards>
-  <Card
-    title="Learn about customizing cell plugins"
-    href="/docs/blocks/table-view/tutorial"
-  />
+  <Card title="Create a Cell Plugin" href="/docs/blocks/table-view/tutorial" />
 </Cards>

--- a/apps/docs/content/docs/blocks/table-view/index.mdx
+++ b/apps/docs/content/docs/blocks/table-view/index.mdx
@@ -1,36 +1,18 @@
 ---
 title: Table View
-description: An composable, editable data table.
+description: A composable, editable data table with multiple layouts.
 ---
 
-<ComponentPreview name="table-view-uncontrolled" />
+<ComponentPreview name="table-view-uncontrolled" hideCode />
 
-## Supported Features
+## Features
 
-- Controlled/Uncontrolled state management
-
-- Column actions: CRUD, DND, duplicating
-
-- Row actions: CRUD, DND, duplicating
-
-- Column wrapping
-
-- Column pinning
-
-- Column type changing
-
-- Table: sorting, grouping
-
-- Table Views: Table, List, Board, Timeline
-
-- Cells plugins
-  - Required plugins: `title`, `text`
-  - Selectable: `checkbox`, `select`, `multi-select`
-  - Numeric inputs: `number`
-  - External links: `email`, `phone`, `url`
-  - Date & time: `date`, `created-time`, `last-edited-time`
-
-- Open row as: center dialog, side peek, or full page
+- Controlled or uncontrolled resources for rows, properties, and view state
+- Create, edit, duplicate, reorder, hide, and resize properties and rows
+- Sort, group, calculate, and bulk-edit selected rows
+- Table, List, Board, and Timeline layouts
+- Open rows in a center dialog, side pane, or full page
+- Built-in plugins for title, text, number, checkbox, select, multi-select, links, and dates
 
 ## Installation
 
@@ -39,31 +21,32 @@ description: An composable, editable data table.
   registryName="table-view-controlled"
 />
 
-## Note
+## Requirements
 
-<Callout>
-  - 1. Every table should have at least two plugins: `title()` and `text()`
-  
-  - 2. Every table should have exactly one `title` property.
-
-</Callout>
+`TableView` uses `DEFAULT_PLUGINS` when no `plugins` prop is supplied. When you
+provide `plugins`, include the plugin factories your properties use. Every table
+needs exactly one `title` property so rows have a label in every layout.
 
 ## Examples
 
----
-
 ### Uncontrolled Table
+
+Use `defaultData`, `defaultProperties`, and `defaultView` when the table owns
+its state. These defaults are read once when the component mounts; remount with
+a different `key` to reset the table.
 
 <ComponentPreview
   name="table-view-uncontrolled"
   preview={`<TableView
     defaultProperties={properties}
     defaultData={data}
-  />
-  `}
+  />`}
 />
 
 ### Controlled Table
+
+Pass a resource and apply each callback's `next` value to keep it authoritative.
+Rows, properties, and view state can be controlled independently.
 
 <ComponentPreview
   name="table-view-controlled"
@@ -74,158 +57,71 @@ description: An composable, editable data table.
     onPropertiesChange={({ next }) => setProperties(next)}
     view={view}
     onViewChange={({ next }) => setView(next)}
-  />
-  `}
+  />`}
 />
 
-Controlled resources are authoritative. `TableView` calls each replacement
-callback with a `{ next, action }` envelope, and the rendered table updates
-after the owner commits `next` through props. React state handlers should
-destructure `next`. Backend mutation functions can accept the complete
-resource-change envelope directly.
+Do not switch a resource between controlled and uncontrolled during one mount.
 
-```tsx
-const replaceData = useMutation({ mutationFn: api.replaceData });
+### Timeline layout
 
-<TableView data={data} onDataChange={replaceData.mutate} />;
-```
-
-`action` is a typed audit payload with a generated id. When one operation
-changes more than one resource, such as creating a property and initializing
-cells for every row, the emitted resource changes share the same action id.
-Use `serializeResourceAction(change)` when creating an activity-log record so
-the log stores the compact action payload and not the complete replacement
-resource.
-
-Uncontrolled resources use `defaultData`, `defaultProperties`, and
-`defaultView`. Defaults are read only on mount; reset an uncontrolled table by
-remounting it with a new React `key`.
-
-## Timeline layout
-
-Set `layout` to `"timeline"` and identify the Date property that places rows on
-the timeline. The public `timeline` field is optional. Internally, it defaults
-to a monthly range and no persisted Date-property selection:
+Set the layout to `"timeline"` and select a Date property for the timeline.
+The range can be daily, monthly, or quarterly.
 
 ```tsx
 const view = {
   layout: "timeline",
-  rowView: "side",
-  openedRowId: null,
-  locked: false,
   timeline: {
     range: "monthly",
-    datePropertyId: null,
+    datePropertyId: "due-date",
   },
-} satisfies TableViewState;
+};
+
+<TableView
+  defaultProperties={properties}
+  defaultData={data}
+  defaultView={view}
+/>;
 ```
 
-When `datePropertyId` is `null`, missing, hidden, deleted, or not a `date`
-property, Timeline resolves the first visible, non-deleted Date property. An
-unlocked table persists that resolution with
-`view.timeline_property.change`. If no usable Date property exists, Timeline
-appends a Date property with a unique name based on `Timeline` (for example,
-`Timeline` or `Timeline 1`) and selects it. When rows exist, Timeline also
-initializes one cell for every row. Each seeded cell has this value:
+## Custom cell plugins
 
-```ts
-{
-  start: row.createdAt,
-  end: Math.max(row.createdAt, row.lastEditedAt),
-  endDate: true,
-}
-```
+Create a custom plugin when a property needs its own value display, editor, or
+configuration. A plugin that provides `renderCellEditor` also participates in
+bulk editing by default.
 
-With rows present, automatic initialization emits `properties.create`,
-`data.cell.update`, and `view.timeline_property.change`, in that order, with
-one shared action id. An empty table has no cells to seed, so it emits only
-`properties.create` and `view.timeline_property.change`, with the same shared
-id. Controlled owners must accept the property and view `next` resources to
-leave the pending state and render Timeline. When rows exist, they must also
-accept the data `next` resource to preserve the initialized row values.
-
-Existing empty Date cells are not seeded. They remain empty tracks. In an
-unlocked Timeline, selecting an empty track creates a one-calendar-day value;
-moving or resizing a bar also replaces the cell value. These writes emit
-`data.cell.update` with the row id, property id, previous value, and next
-`{ start, end, endDate: true }` value.
-
-Other Timeline interactions use the same controlled resource API:
-
-- changing the range emits `view.timeline_range.change`;
-
-- choosing a Date property emits `view.timeline_property.change`;
-
-- reordering a sidebar row emits `data.row.move`;
-
-- opening a row emits `view.opened_row.change`.
-
-Locked Timelines remain navigable, so existing bars and row titles can still
-open rows. They do not show empty-track add controls, bar resizers, row drag
-handles, or the title-column resizer, and range changes do not write view
-state. A locked table without a usable Date property renders an empty
-read-only Timeline and does not create a property, seed cells, or repair the
-selection.
-
-## Reactive custom children
-
-`TableView` does not rerender custom children for every internal store update.
-Read store-backed values through `table.Subscribe` and select only the state
-used by the child:
-
-```tsx
-import { useTableViewCtx } from "@notion-kit/table-view";
-
-function CurrentLayout() {
-  const { table } = useTableViewCtx();
-
-  return (
-    <table.Subscribe selector={(state) => state.tableGlobal.layout}>
-      {(layout) => <span>Current layout: {layout}</span>}
-    </table.Subscribe>
-  );
-}
-```
-
-Values read directly from `table.store.state` or snapshot helpers such as
-`table.getTableGlobalState()` are not reactive by themselves. A custom child
-that only reads a snapshot can become stale after internal store updates.
+<Cards>
+  <Card title="Create a Cell Plugin" href="/docs/blocks/table-view/tutorial" />
+  <Card title="Cell Plugin API" href="/docs/blocks/table-view/cell-plugins" />
+</Cards>
 
 ## API Reference
 
 ### TableView
 
-A `TableView` is a generic component `TableView<TPlugins>` where `TPlugins` extends `CellPlugin[]`.
-It provides a table view with editable cells and supports various plugins for cell types.
+| Prop                 | Type                        | Description                                                             |
+| -------------------- | --------------------------- | ----------------------------------------------------------------------- |
+| `plugins`            | `CellPlugin[]`              | Plugin factories available to the table. Defaults to `DEFAULT_PLUGINS`. |
+| `data`               | `Row[]`                     | Controlled rows resource.                                               |
+| `defaultData`        | `Row[]`                     | Initial rows for an uncontrolled table.                                 |
+| `properties`         | `ColumnDefs`                | Controlled properties resource.                                         |
+| `defaultProperties`  | `ColumnDefs`                | Initial properties for an uncontrolled table.                           |
+| `view`               | `PartialTableViewState`     | Controlled layout and presentation state.                               |
+| `defaultView`        | `PartialTableViewState`     | Initial view state for an uncontrolled table.                           |
+| `onDataChange`       | `(change) => void`          | Receives the next rows resource and its action.                         |
+| `onPropertiesChange` | `(change) => void`          | Receives the next properties resource and its action.                   |
+| `onViewChange`       | `(change) => void`          | Receives the next view resource and its action.                         |
+| `getRowUrl`          | `(rowId: string) => string` | Returns the URL used when opening a row in a new tab.                   |
+| `weekStartsOn`       | `Weekday`                   | Sets the first day of the week for date-based features.                 |
+| `defaultColumn`      | `Partial<ColumnDef>`        | Overrides the default TanStack Table column options.                    |
+| `children`           | `ReactNode`                 | Content rendered inside the Table View provider.                        |
 
-| Prop                 | Type                                                                                  | Description                                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `plugins`            | `TPlugins`                                                                            | The plugins to use for the table. Each table should contain at least `title()` and `text()` plugins. |
-| `data`               | [`Row<TPlugins>[]`](/docs/objects/database-properties#row)                            | Controlled rows resource. Do not combine with `defaultData`.                                         |
-| `defaultData`        | [`Row<TPlugins>[]`](/docs/objects/database-properties#row)                            | Mount-only uncontrolled rows default. Do not combine with `data`.                                    |
-| `properties`         | [`ColumnDefs<TPlugins>`](/docs/objects/database-properties#columndefs)                | Controlled column definitions resource. Do not combine with `defaultProperties`.                     |
-| `defaultProperties`  | [`ColumnDefs<TPlugins>`](/docs/objects/database-properties#columndefs)                | Mount-only uncontrolled column definitions default. Do not combine with `properties`.                |
-| `view`               | [`Partial<TableViewState>`](#type-tableviewstate)                                     | Controlled view presentation resource. Do not combine with `defaultView`.                            |
-| `defaultView`        | [`Partial<TableViewState>`](#type-tableviewstate)                                     | Mount-only uncontrolled view default. Do not combine with `view`.                                    |
-| `onDataChange`       | `(change: ResourceChange<Row<TPlugins>[], DataResourceAction>) => unknown`            | Complete rows replacement envelope with an audit action.                                             |
-| `onPropertiesChange` | `(change: ResourceChange<ColumnDefs<TPlugins>, PropertiesResourceAction>) => unknown` | Complete column definitions replacement envelope with an audit action.                               |
-| `onViewChange`       | `(change: ResourceChange<TableViewState, ViewResourceAction>) => unknown`             | Complete view replacement envelope with an audit action.                                             |
+### TableViewState
 
-### `type` TableState
-
-A `TableState` is a generic type `TableState<TPlugins>` that represents the state of a table, including its column definitions and row data.
-
-| Prop           | Type                                                                   | Default | Description                          |
-| -------------- | ---------------------------------------------------------------------- | ------- | ------------------------------------ |
-| `properties`\* | [`ColumnDefs<TPlugins>`](/docs/objects/database-properties#columndefs) | -       | The column definitions of the table. |
-| `data`\*       | [`Row<TPlugins>[]`](/docs/objects/database-properties#row)             | -       | The rows of the table.               |
-
-### `type` TableViewState
-
-| Prop          | Type                                                                               | Default                                      | Description                                                                                                                    |
-| ------------- | ---------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `layout`      | `"table" \| "list" \| "board" \| "timeline" \| "calendar" \| "gallery" \| "chart"` | `"table"`                                    | The layout view. Table, List, Board, and Timeline are implemented; the other typed values currently render the table fallback. |
-| `locked`      | `boolean`                                                                          | `false`                                      | Whether the table is locked (non-editable).                                                                                    |
-| `rowView`     | `"center" \| "side" \| "full"`                                                     | `"side"`                                     | The view type of the opened row.                                                                                               |
-| `openedRowId` | `string \| null`                                                                   | `null`                                       | The unique identifier of the opened row.                                                                                       |
-| `timeline`    | `{ range: "daily" \| "monthly" \| "quarterly"; datePropertyId: string \| null }`   | `{ range: "monthly", datePropertyId: null }` | Optional Timeline range and persisted Date-property selection.                                                                 |
+| Field           | Description                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `layout`        | The active layout. Table, List, Board, and Timeline have dedicated renderers; other layout values currently use the table renderer. |
+| `locked`        | Prevents table edits while leaving existing rows navigable.                                                                         |
+| `rowView`       | Where an opened row appears: `center`, `side`, or `full`.                                                                           |
+| `openedRowId`   | The currently opened row, or `null`.                                                                                                |
+| `timeline`      | Optional Timeline configuration containing `range` and `datePropertyId`.                                                            |
+| `pluginMethods` | Persisted sorting, grouping, and group-sort choices for plugins.                                                                    |

--- a/apps/docs/content/docs/blocks/table-view/tutorial.mdx
+++ b/apps/docs/content/docs/blocks/table-view/tutorial.mdx
@@ -1,170 +1,142 @@
 ---
 title: Creating a Cell Plugin
-description: A step-by-step tutorial for building a custom cell plugin in the Notion database.
+description: Build a custom property type for Table View.
 ---
 
-## Introduction
+A cell plugin defines the data model for one property type. It must render a
+cell value; add an editor when users should be able to change that value.
 
-This guide walks you through the process of creating a custom `CellPlugin` to extend the database system with new property types. A cell plugin controls how values are stored, rendered, and interacted with.
+## Create a Tag plugin
 
-## Step-by-Step: Create a "Tag" Plugin
-
-<Steps>
-<Step>
-
-### Define the Types
-
-```ts
-// tag-plugin.tsx
-
-import type { CellPlugin } from "@notion-kit/table-hook/plugins";
-
-export type TagData = string[];
-export interface TagConfig {
-  options: string[];
-}
-export type TagPlugin = CellPlugin<"tag", TagData, TagConfig>;
-```
-
-</Step>
-<Step>
-### Implement the Plugin
+### Define the plugin
 
 ```tsx
-// tag-plugin.tsx
-
-import type { CellProps } from "@notion-kit/table-hook/plugins";
+import type {
+  CellEditorProps,
+  CellPlugin,
+  CellValueProps,
+} from "@notion-kit/table-hook/plugins";
 import { createCompareFn } from "@notion-kit/table-hook/plugins";
+
+type TagData = string[];
+type TagConfig = { options: string[] };
+type TagPlugin = CellPlugin<"tag", TagData, TagConfig>;
+
+const TagIcon = <span aria-hidden>🏷️</span>;
+
+function TagValue({ data }: Pick<CellValueProps<TagData, TagConfig>, "data">) {
+  return <span>{data.join(", ") || "—"}</span>;
+}
+
+function TagEditor({
+  data,
+  config,
+  onChange,
+}: Pick<CellEditorProps<TagData, TagConfig>, "data" | "config" | "onChange">) {
+  return (
+    <div>
+      {config.options.map((tag) => {
+        const selected = data.includes(tag);
+
+        return (
+          <button
+            key={tag}
+            type="button"
+            aria-pressed={selected}
+            onClick={() =>
+              onChange(
+                selected
+                  ? data.filter((value) => value !== tag)
+                  : [...data, tag],
+              )
+            }
+          >
+            {tag}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 export const tagPlugin: TagPlugin = {
   id: "tag",
-  default: {
-    name: "Tags",
-    icon: <TagIcon />, // Your own icon component
-    config: { options: [] },
-    data: [],
-  },
   meta: {
     name: "Tag",
     desc: "A multi-select tag property",
-    icon: <TagIcon />, // Your own icon component
+    icon: TagIcon,
   },
-  fromValue: (value, config) => value.split(",").map((tag) => tag.trim()),
+  default: {
+    name: "Tags",
+    icon: TagIcon,
+    config: { options: [] },
+    data: [],
+  },
+  fromValue: (value) =>
+    typeof value === "string"
+      ? value
+          .split(",")
+          .map((tag) => tag.trim())
+          .filter(Boolean)
+      : [],
   toValue: (data) => data.join(", "),
   toTextValue: (data) => data.join(", "),
   compare: createCompareFn<TagPlugin>((a, b) =>
-    (a[0] ?? "").localeCompare(b[0] ?? ""),
+    a.join(", ").localeCompare(b.join(", ")),
   ),
-  renderCell: (props) => <TagCell {...props} />,
-  renderConfigMenu: (props) => <TagConfigMenu {...props} />,
+  renderCellValue: (props) => <TagValue {...props} />,
+  renderCellEditor: (props) => ({
+    presentation: "popover",
+    content: <TagEditor {...props} />,
+  }),
 };
 ```
 
-</Step>
-<Step>
-### Render the Cell Component
+`renderCellEditor` receives a `scope`. It is `{ kind: "cell" }` for a single
+cell and `{ kind: "bulk" }` when the bulk-edit bar invokes the same editor for
+selected rows. The example does not need to branch on the scope, so it supports
+both paths automatically.
 
-```tsx
-// tag-plugin.tsx
+### Register the plugin
 
-import type { ConfigMenuProps } from "@notion-kit/table-hook/plugins";
-
-function TagCell({
-  data: tags,
-  config,
-  onChange,
-}: CellProps<TagData, TagConfig>) {
-  const options = config?.options ?? [];
-  return (
-    <div>
-      {options.map((tag) => (
-        <Badge
-          key={tag}
-          onClick={() => {
-            if (!onChange) return;
-            const next = tags.includes(tag)
-              ? tags.filter((t) => t !== tag)
-              : [...tags, tag];
-            onChange(next);
-          }}
-        >
-          {tag} {tags.includes(tag) ? "✅" : ""}
-        </Badge>
-      ))}
-    </div>
-  );
-}
-```
-
-</Step>
-<Step>
-### `Optional` Configuration Menu
-
-```tsx
-// tag-plugin.tsx
-
-function TagConfigMenu({
-  config,
-  propId,
-  onChange,
-}: ConfigMenuProps<TagConfig>) {
-  return (
-    <div>
-      <label htmlFor={`${propId}-options`}>
-        Tag Options (comma separated):
-      </label>
-      <input
-        id={`${propId}-options`}
-        defaultValue={config?.options?.join(", ") ?? ""}
-        onBlur={(e) => {
-          const options = e.target.value.split(",").map((o) => o.trim());
-          // persist config change using your system
-          onChange({ options });
-        }}
-      />
-    </div>
-  );
-}
-```
-
-</Step>
-<Step>
-### Register the Plugin
-
-Finally, register your plugin in the table view:
+Add the plugin to the list passed to `TableView`, then include a matching
+property in the table data.
 
 ```tsx
 import { DEFAULT_PLUGINS, TableView } from "@notion-kit/table-view";
+import type { ColumnDefs, Row } from "@notion-kit/table-view";
 
 import { tagPlugin } from "./tag-plugin";
 
-const properties = [
-  { id: "name", name: "Name", type: "title" as const },
+const plugins = [...DEFAULT_PLUGINS, tagPlugin];
+
+const properties: ColumnDefs<typeof plugins> = [
+  { id: "name", name: "Name", type: "title" },
   {
     id: "tags",
     name: "Tags",
-    type: "tag" as const,
+    type: "tag",
     config: { options: ["Bug", "Feature"] },
   },
 ];
 
 const now = Date.now();
-const data = [
+const data: Row<typeof plugins>[] = [
   {
     id: "task-1",
     createdAt: now,
     lastEditedAt: now,
     properties: {
-      name: { id: "task-1-name", value: "Ship table view" },
+      name: { id: "task-1-name", value: "Ship Table View" },
       tags: { id: "task-1-tags", value: ["Feature"] },
     },
   },
 ];
 
-function DatabaseView() {
+export function DatabaseView() {
   return (
     <TableView
-      plugins={[...DEFAULT_PLUGINS, tagPlugin]} // Register your custom plugin here // [!code highlight]
+      plugins={plugins}
       defaultProperties={properties}
       defaultData={data}
     />
@@ -172,9 +144,6 @@ function DatabaseView() {
 }
 ```
 
-</Step>
-</Steps>
-
----
-
-This plugin system makes your table highly extensible while maintaining strong typing. You can now build more plugins like number pickers, multi-selects, color swatches, or even embedded widgets.
+Add `renderConfigMenu` when users need to edit the property configuration, and
+add sorting, grouping, or counting methods only when the property needs those
+capabilities.

--- a/apps/docs/content/docs/changelog.mdx
+++ b/apps/docs/content/docs/changelog.mdx
@@ -3,6 +3,44 @@ title: Changelog
 description: Latest updates and improvements to Notion UI.
 ---
 
+<ChangelogBlock version="v1.1.0">
+
+### 🧮 NK-34 & NK-45: A more capable Table View
+
+Table View is now powered by TanStack Table v9 and includes bulk editing for selected rows.
+
+**What's new:**
+
+- **Bulk Editing:** Select multiple rows and update compatible properties together, including text, number, select, checkbox, and date fields.
+- **Extensible Editors:** Custom plugins can opt into bulk editing by providing a cell editor, without special-case integration in Table View.
+- **Stronger Table Foundation:** `@notion-kit/table-hook`, `@notion-kit/table-view`, and Settings Panel tables have been migrated to TanStack Table v9 for more reliable sorting, grouping, row actions, and controlled state.
+
+### 🗿 NK-51 & NK-54: Base UI primitives
+
+Notion Kit's UI primitives have been migrated to Base UI, improving their underlying accessibility and interaction behavior while preserving the familiar Notion Kit look and feel.
+
+**What's new:**
+
+- **Expanded primitives:** Added `Autocomplete`, `Combobox`, `Meter`, and `Sortable` alongside refreshed menu, select, dialog, tooltip, tabs, and form primitives.
+- **New blocks:** Added a Kanban block to `@notion-kit/ui`.
+- **Updated component APIs:** Several primitives now use the Base UI composition model; review the updated component documentation when upgrading.
+
+### 🕶️ NK-52: Cool Blocks
+
+Added `@notion-kit/cool-blocks`, a collection of expressive, interactive React blocks for playful product moments.
+
+**What's included:**
+
+- **Eject:** Animate content out of view, with disappear, respawn, and ghost modes.
+- **Falling Blocks:** A physics-driven, draggable falling-blocks interaction.
+- **Sling Shot:** A draggable slingshot-style interaction component.
+
+### 🗺️ NK-49 & NK-50: Transit map data and visualization
+
+Expanded the map platform with Transitland-backed transit data, real-time vehicle updates, routes, stops, trip details, and a dedicated interactive globe application.
+
+</ChangelogBlock>
+
 <ChangelogBlock version="v1.0.0">
 
 ### 🚀 NK-40: Single UI Package

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/docs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "build": "pnpm build:registry && next build",

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/e2e",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/globe/package.json
+++ b/apps/globe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/globe",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/map-server/package.json
+++ b/apps/map-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/map-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/storybook",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/notion-clone/package.json
+++ b/examples/notion-clone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/notion-clone",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "build": "pnpm with-env next build",

--- a/examples/notion-table/package.json
+++ b/examples/notion-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/notion-table",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-kit",
-  "version": "0.16.0",
+  "version": "1.1.0",
   "private": true,
   "engines": {
     "node": ">=24.11.0",

--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/auth-ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/auth",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"

--- a/packages/cn/package.json
+++ b/packages/cn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/cn",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"

--- a/packages/code-block/package.json
+++ b/packages/code-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/code-block",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"
   },

--- a/packages/cool-blocks/package.json
+++ b/packages/cool-blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/cool-blocks",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"
   },

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/hooks",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/i18n",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/icons",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/map",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/registry",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"
   },

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/schemas",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"

--- a/packages/settings-panel/package.json
+++ b/packages/settings-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/settings-panel",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"
   },

--- a/packages/table-hook/package.json
+++ b/packages/table-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/table-hook",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"
   },

--- a/packages/table-view/package.json
+++ b/packages/table-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/table-view",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/utils",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "bugs": {
     "url": "https://github.com/steeeee0223/notion-kit/issues"

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/validators",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/tooling/config/package.json
+++ b/tooling/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@notion-kit/config",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "exports": {
     "./rsbuild": "./rsbuild.config.ts",

--- a/tooling/eslint/package.json
+++ b/tooling/eslint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@notion-kit/eslint-config",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "exports": {
     "./base": "./base.ts",

--- a/tooling/prettier/package.json
+++ b/tooling/prettier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@notion-kit/prettier-config",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "exports": {
     ".": "./index.js"

--- a/tooling/tailwind/package.json
+++ b/tooling/tailwind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notion-kit/tailwind-config",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "exports": {
     "./base.css": "./base.css"

--- a/tooling/typescript/package.json
+++ b/tooling/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@notion-kit/tsconfig",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "files": [
     "*.json"
   ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepares the 1.1.0 release and fixes the CI bootstrap to reliably build and publish packages. Old: Turbo build with implicit npm auth; New: `pnpm build --filter=${PACKAGE_NAME}` with explicit npm auth set before `npm publish`.

- Versions: root `notion-kit` is 1.1.0; all publishable packages are 1.1.0; `@notion-kit/globe` is 1.0.0.
- Docs: refreshes Table View docs and tutorial; adds a `v1.1.0` changelog entry.
- No runtime or dependency changes.
- Migration: bump consumers to `^1.1.0`.
- Release: tag `v1.1.0` and publish updated packages.

<sup>Written for commit 0d2838da1645cdfd20b60db99dbfb937e724ed3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/steeeee0223/notion-kit/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

